### PR TITLE
Split of `trdelnik test` command into the two phases: 1. `trdelnik build` 2. `trdelnik test`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ developed by [Ackee Blockchain](https://ackeeblockchain.com)
 
 <div align="left">
 
-Trdelník is Rust based testing framework providing several convenient developer tools for testing Solana programs written in [Anchor](https://github.com/project-serum/anchor).
+Trdelník is rust based testing framework providing several convenient developer tools for testing Solana programs written in [Anchor](https://github.com/project-serum/anchor).
 
 - _Trdelnik client_ - build and deploy an Anchor program to a local cluster and run a test suite against it.
 - _Trdelnik console_ - built-in console to give developers a command prompt for quick program interaction.
 - _Trdelnik fuzz_ - property-based and stateful testing.
-- _Trdelnik explorer_ - exploring a ledger changes.
+- _Trdelnik explorer_ - exploring ledger changes.
 
 </div>
 
@@ -42,18 +42,18 @@ Trdelník is Rust based testing framework providing several convenient developer
 <!-- Installation -->
 
 ## **Installation**
-Currently only by cloning the repo and building from source. See [Examples](#examples)
+Currently, only by cloning the repo and building from the source. See [Examples](#examples)
 
 <!-- Examples -->
 
 ## **Examples**
-Here's a test of [turnstile program](examples/turnstile/programs/turnstile/src/lib.rs).Currently there are few compulsory step you need to follow:
+Here's a test of [turnstile program](examples/turnstile/programs/turnstile/src/lib.rs). Currently, there are a few compulsory steps you need to follow:
 
-- Import of the `trdelnik_client` crate.
-- Run `makers trdelnik build` in order to generate a `program_client` crate (containing an auto generated code for easy invocation of instructions of your program)
-- Add `program_client` crate into your `Cargo.toml` and import it to the test (as shown bellow).
-- Now you can easilly invoke instructions of your program and do whatever you want in your test.
-- After you are finished with your tests run `makers trdelnik test` and check the results.
+- Import the `trdelnik_client` crate.
+- Run `makers trdelnik build` to generate a `program_client` crate (containing an auto-generated code for easy invocation of instructions of your program)
+- Add the `program_client` crate into your `Cargo.toml` and import it to the test (as shown below).
+- Now, you can easily invoke instructions of your program and do whatever you want in your test.
+- After you are finished with your tests, run `makers trdelnik test` and check the results.
 ```rust
 // ...
 use program_client::turnstile_instruction;

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ Currently only by cloning the repo and building from source. See [Examples](#exa
 Here's a test of [turnstile program](examples/turnstile/programs/turnstile/src/lib.rs).Currently there are few compulsory step you need to follow:
 
 - Import of the `trdelnik_client` crate.
-- Create an empty test and annotate it with the `trdelnik_test` macro (as shown bellow).
-- Run `makers trdelnik test` in order to generate a `program_client` crate (containing an auto generated code for easy invocation of instructions of your program)
+- Run `makers trdelnik build` in order to generate a `program_client` crate (containing an auto generated code for easy invocation of instructions of your program)
 - Add `program_client` crate into your `Cargo.toml` and import it to the test (as shown bellow).
 - Now you can easilly invoke instructions of your program and do whatever you want in your test.
 - After you are finished with your tests run `makers trdelnik test` and check the results.

--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -1,3 +1,6 @@
+mod build;
+pub use build::build;
+
 mod test;
 pub use test::test;
 

--- a/crates/cli/src/command/build.rs
+++ b/crates/cli/src/command/build.rs
@@ -1,0 +1,12 @@
+use anyhow::Error;
+use fehler::throws;
+use trdelnik_client::*;
+
+#[throws]
+pub async fn build(root: String) {
+    let commander = Commander::with_root(root);
+    commander.create_program_client_crate().await?;
+    commander.build_programs().await?;
+    commander.generate_program_client_deps().await?;
+    commander.generate_program_client_lib_rs().await?;
+}

--- a/crates/cli/src/command/test.rs
+++ b/crates/cli/src/command/test.rs
@@ -5,9 +5,5 @@ use trdelnik_client::*;
 #[throws]
 pub async fn test(root: String) {
     let commander = Commander::with_root(root);
-    commander.create_program_client_crate().await?;
-    commander.build_programs().await?;
-    commander.generate_program_client_deps().await?;
-    commander.generate_program_client_lib_rs().await?;
     commander.run_tests().await?;
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -13,6 +13,12 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// Create a `program_client` crate 
+    Build {
+        /// Anchor project root
+        #[clap(short, long, default_value = "./")]
+        root: String,
+    },
     /// Run program tests
     Test {
         /// Anchor project root
@@ -28,6 +34,7 @@ pub async fn start() {
     let cli = Cli::parse();
 
     match cli.command {
+        Command::Build { root } => command::build(root).await?,
         Command::Test { root } => command::test(root).await?,
         Command::Localnet => command::localnet().await?,
     }


### PR DESCRIPTION
It eliminates the need to build a crate `program_client` each time a test is run and at the same time allows this package to be used the first time the test is run.