### PR TITLE
🐛 replace dash with underscore in instruction name

### DIFF
--- a/crates/client/src/program_client_generator.rs
+++ b/crates/client/src/program_client_generator.rs
@@ -11,9 +11,9 @@ pub fn generate_source_code(idl: Idl) -> String {
         .programs
         .into_iter()
         .map(|idl_program| {
-            let instruction_module_name =
-                format_ident!("{}_instruction", idl_program.name.snake_case);
-            let module_name: syn::Ident = parse_str(&idl_program.name.snake_case).unwrap();
+            let program_name = idl_program.name.snake_case.replace('-', "_");
+            let instruction_module_name = format_ident!("{}_instruction", program_name);
+            let module_name: syn::Ident = parse_str(&program_name).unwrap();
             let pubkey_bytes: syn::ExprArray = parse_str(&idl_program.id).unwrap();
 
             let instructions = idl_program


### PR DESCRIPTION
When the program name contains dash `my-program` and we are trying to create a program_client instruction, the name `my-program_instruction` is not valid. So I added a fix which replace the dash with underscore `my_program_instruction` which is a valid identifier.