### PR TITLE
Ignore IntelliJ project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 test-ledger
+
+.idea


### PR DESCRIPTION
Since VSCode seems to be the recommended IDE ignoring project files created by JetBrains IDEs might be a good idea to prevent accidental commits.