### PR TITLE
Improved the program deployment procedure even further

### DIFF
--- a/examples/escrow/.program_client/Cargo.toml
+++ b/examples/escrow/.program_client/Cargo.toml
@@ -2,9 +2,8 @@
 name = "program_client"
 version = "0.1.0"
 edition = "2018"
-
-[dependencies]
-trdelnik-client = { path = "../../../crates/client" }
+[dependencies.trdelnik-client]
+path = "../../../crates/client"
 
 [dependencies.escrow]
 path = "../programs/escrow"

--- a/examples/escrow/.program_client/src/lib.rs
+++ b/examples/escrow/.program_client/src/lib.rs
@@ -2,9 +2,9 @@
 pub mod escrow_instruction {
     use trdelnik_client::*;
     pub static PROGRAM_ID: Pubkey = Pubkey::new_from_array([
-        5u8, 214u8, 204u8, 101u8, 166u8, 163u8, 239u8, 244u8, 13u8, 110u8, 64u8, 106u8, 230u8,
-        81u8, 141u8, 186u8, 208u8, 155u8, 78u8, 83u8, 194u8, 215u8, 103u8, 17u8, 94u8, 15u8, 137u8,
-        68u8, 170u8, 153u8, 74u8, 59u8,
+        5u8, 215u8, 176u8, 66u8, 255u8, 47u8, 77u8, 122u8, 100u8, 249u8, 156u8, 251u8, 44u8, 92u8,
+        36u8, 220u8, 226u8, 147u8, 127u8, 109u8, 198u8, 92u8, 1u8, 127u8, 95u8, 116u8, 186u8,
+        180u8, 149u8, 157u8, 170u8, 34u8,
     ]);
     pub async fn initialize_escrow(
         client: &Client,

--- a/examples/escrow/Cargo.lock
+++ b/examples/escrow/Cargo.lock
@@ -3518,6 +3518,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "solana-account-decoder",
  "solana-cli-output",
  "solana-sdk",
  "solana-transaction-status",

--- a/examples/escrow/programs/escrow/src/lib.rs
+++ b/examples/escrow/programs/escrow/src/lib.rs
@@ -19,7 +19,7 @@ use anchor_lang::prelude::*;
 use anchor_spl::token::{self, SetAuthority, Token, TokenAccount, Transfer};
 use spl_token::instruction::AuthorityType;
 
-declare_id!("Po1RaS8BEDbNcn5oXsFryAeQ6Wn8fvmE111DJaKCgPC");
+declare_id!("Poo5jhFcGjMjYaz2cpmSNVq4ehvjKJhjU7aCZiS2LMP");
 
 #[program]
 pub mod escrow {

--- a/examples/escrow/trdelnik-tests/tests/test.rs
+++ b/examples/escrow/trdelnik-tests/tests/test.rs
@@ -178,7 +178,6 @@ async fn test_happy_path2(#[future] init_fixture: Result<Fixture>) {
 
 struct Fixture {
     client: Client,
-    program: Keypair,
     // Mint stuff
     mint_a: Keypair,
     mint_b: Keypair,
@@ -200,7 +199,6 @@ impl Fixture {
     fn new() -> Self {
         Fixture {
             client: Client::new(system_keypair(0)),
-            program: program_keypair(1),
 
             mint_a: keypair(1),
             mint_b: keypair(2),
@@ -226,7 +224,7 @@ impl Fixture {
             .airdrop(self.alice_wallet.pubkey(), 5_000_000_000)
             .await?;
         self.client
-            .deploy_by_name(&self.program.clone(), "escrow")
+            .deploy_all_programs()
             .await?;
     }
 

--- a/examples/turnstile/.program_client/src/lib.rs
+++ b/examples/turnstile/.program_client/src/lib.rs
@@ -2,9 +2,9 @@
 pub mod turnstile_instruction {
     use trdelnik_client::*;
     pub static PROGRAM_ID: Pubkey = Pubkey::new_from_array([
-        5u8, 214u8, 204u8, 101u8, 166u8, 163u8, 239u8, 244u8, 13u8, 110u8, 64u8, 106u8, 230u8,
-        81u8, 141u8, 186u8, 208u8, 155u8, 78u8, 83u8, 194u8, 215u8, 103u8, 17u8, 94u8, 15u8, 137u8,
-        68u8, 170u8, 153u8, 74u8, 59u8,
+        5u8, 215u8, 176u8, 66u8, 255u8, 47u8, 77u8, 122u8, 100u8, 249u8, 156u8, 251u8, 44u8, 92u8,
+        36u8, 220u8, 226u8, 147u8, 127u8, 109u8, 198u8, 92u8, 1u8, 127u8, 95u8, 116u8, 186u8,
+        180u8, 149u8, 157u8, 170u8, 34u8,
     ]);
     pub async fn initialize(
         client: &Client,

--- a/examples/turnstile/programs/turnstile/src/lib.rs
+++ b/examples/turnstile/programs/turnstile/src/lib.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-declare_id!("Po1RaS8BEDbNcn5oXsFryAeQ6Wn8fvmE111DJaKCgPC");
+declare_id!("Poo5jhFcGjMjYaz2cpmSNVq4ehvjKJhjU7aCZiS2LMP");
 
 #[program]
 pub mod turnstile {

--- a/examples/turnstile/trdelnik-tests/tests/test.rs
+++ b/examples/turnstile/trdelnik-tests/tests/test.rs
@@ -9,14 +9,13 @@ async fn init_fixture() -> Fixture {
     // create a test fixture
     let fixture = Fixture {
         client: Client::new(system_keypair(0)),
-        program: program_keypair(1),
         state: keypair(42),
     };
 
     // deploy a tested program
     fixture
         .client
-        .deploy_by_name(&fixture.program, "turnstile")
+        .deploy_all_programs()
         .await?;
 
     // init instruction call
@@ -74,7 +73,6 @@ async fn test_unhappy_path(#[future] init_fixture: Result<Fixture>) {
 
 struct Fixture {
     client: Client,
-    program: Keypair,
     state: Keypair,
 }
 


### PR DESCRIPTION
- implemented the `deploy_all_programs` function
- ~~refactored the code to use the `utils` (`trdelnik-utils`) crate to get rid of some (potentially) duplicated code~~
- ~~removed the first keypair from `PROGRAM_KEYPAIRS` which somehow fails to find a program after deployment~~
  - ~~this might be just some mistake on my side and might need to be doublechecked~~