### PR TITLE
✨ Added the key-pair command to print information about a key-pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ async fn init_fixture() -> Fixture {
   // create a test fixture
   let mut fixture = Fixture {
     client: Client::new(system_keypair(0)),
+    // make sure your program is using a correct program ID
     program: program_keypair(1),
     state: keypair(42),
   };
@@ -105,6 +106,15 @@ async fn test_happy_path(#[future] init_fixture: Result<Fixture>) {
   assert_eq!(state.something_changed, "yes");
 }
 ```
+
+Make sure your program is using a correct program ID in the `derive_id!(...)` macro and inside `Anchor.toml`.
+If not, obtain the public key of a key pair you're using and replace it in these two places.
+To get the program ID of a key pair (key pair's public key) the `trdelnik key-pair` command can be used.
+For example
+```
+$ trdelnik key-pair program 7
+```
+will print information about the key pair received from `program_keypair(7)`.
 
 #### Skipping tests
 
@@ -188,7 +198,7 @@ Thank you for your interest in contributing to Trdelník! Please see the [CONTRI
 
 This project is licensed under the [MIT license](https://github.com/Ackee-Blockchain/trdelnik/blob/master/LICENSE).
 
-## University and investment partners 
+## University and investment partners
 
 - [Czech technical university in Prague](https://www.cvut.cz/en)
 - [Ackee](https://www.ackee.cz/)

--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -1,6 +1,9 @@
 mod build;
 pub use build::build;
 
+mod keypair;
+pub use keypair::{keypair, KeyPairCommand};
+
 mod test;
 pub use test::test;
 

--- a/crates/cli/src/command/keypair.rs
+++ b/crates/cli/src/command/keypair.rs
@@ -1,0 +1,24 @@
+use anyhow::Error;
+use clap::Subcommand;
+use fehler::throws;
+use solana_sdk::signer::Signer;
+use trdelnik_client::{keypair as other_keypair, program_keypair, system_keypair};
+
+#[derive(Subcommand)]
+pub enum KeyPairCommand {
+    Program { n: usize },
+    System { n: usize },
+    Other { n: usize },
+}
+
+#[throws]
+pub fn keypair(subcmd: KeyPairCommand) {
+    let kp: solana_sdk::signer::keypair::Keypair = match subcmd {
+        KeyPairCommand::Program { n } => program_keypair(n),
+        KeyPairCommand::System { n } => system_keypair(n),
+        KeyPairCommand::Other { n } => other_keypair(n),
+    };
+
+    println!("PubKey: {:?}", kp.pubkey());
+    println!("KeyPair: {:?}", kp.to_bytes());
+}

--- a/crates/cli/src/command/keypair.rs
+++ b/crates/cli/src/command/keypair.rs
@@ -13,7 +13,7 @@ pub enum KeyPairCommand {
 
 #[throws]
 pub fn keypair(subcmd: KeyPairCommand) {
-    let kp: solana_sdk::signer::keypair::Keypair = match subcmd {
+    let kp = match subcmd {
         KeyPairCommand::Program { n } => program_keypair(n),
         KeyPairCommand::System { n } => system_keypair(n),
         KeyPairCommand::Other { n } => other_keypair(n),

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -6,6 +6,7 @@ use fehler::throws;
 mod command;
 // bring nested subcommand enums into scope
 use command::ExplorerCommand;
+use command::KeyPairCommand;
 
 #[derive(Parser)]
 #[clap(version, propagate_version = true)]
@@ -21,6 +22,11 @@ enum Command {
         /// Anchor project root
         #[clap(short, long, default_value = "./")]
         root: String,
+    },
+    /// Get information about a keypair
+    KeyPair {
+        #[clap(subcommand)]
+        subcmd: KeyPairCommand,
     },
     /// Run program tests
     Test {
@@ -45,6 +51,7 @@ pub async fn start() {
 
     match cli.command {
         Command::Build { root } => command::build(root).await?,
+        Command::KeyPair { subcmd } => command::keypair(subcmd)?,
         Command::Test { root } => command::test(root).await?,
         Command::Localnet => command::localnet().await?,
         Command::Explorer { subcmd } => command::explorer(subcmd).await?,

--- a/crates/client/src/keys.rs
+++ b/crates/client/src/keys.rs
@@ -8,13 +8,10 @@ pub fn random_keypair() -> Keypair {
 
 /// Returns a recognisable Keypair of your created program. The public key will start with `Pxx`, where
 /// xx are the three digits of the number. `o` is used instead of `0`, as `0` is not part of the base58 charset.
-/// You shouldn't call the method with the same `n` twice. It also prints the program's pubkey so you can copy it
-/// and replace it in your `Anchor.toml` and `programs/<my_program>/lib.rs`.
+/// You shouldn't call the method with the same `n` twice.
 /// The `n` must be a number between `0` and `29`.
 pub fn program_keypair(n: usize) -> Keypair {
-    let keypair = Keypair::from_bytes(&PROGRAM_KEYPAIRS[n]).unwrap();
-    println!("program_keypair({}).pubkey = {}", n, keypair.pubkey());
-    keypair
+    Keypair::from_bytes(&PROGRAM_KEYPAIRS[n]).unwrap()
 }
 
 /// Returns a system wallet (wallet which is owned by the system) but it is not required, you can also use the

--- a/crates/client/src/keys.rs
+++ b/crates/client/src/keys.rs
@@ -1,4 +1,4 @@
-use anchor_client::solana_sdk::{signature::Signer, signer::keypair::Keypair};
+use anchor_client::solana_sdk::signer::keypair::Keypair;
 use rand::rngs::OsRng;
 
 /// Generate a random keypair.

--- a/examples/escrow/Cargo.lock
+++ b/examples/escrow/Cargo.lock
@@ -3518,6 +3518,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "solana-account-decoder",
  "solana-cli-output",
  "solana-sdk",
  "solana-transaction-status",


### PR DESCRIPTION
Added a command to print information about a key pair.

Supports all functions from `crates/cli/src/command/keypair.rs` that fetch pre-generated key pairs.
`program_keypair(n)` using `program`, `system_keypair(n)` using `system` and `keypair(n)` from  using the `other` subcommand.

Example:
```
$> trdelnik key-pair program 7
PubKey: Po7n8ATA5xCAR3wbj3AHk5vCWybTsr6hXRj125jsLmV
KeyPair: [35, 35, 155, 136, 3, 80, 201, 174, 251, 247, 24, 245, 74, 195, 181, 124, 28, 139, 208, 108, 84, 237, 239, 210, 32, 198, 77, 34, 0, 229, 129, 117, 5, 214, 236, 27, 246, 56, 249, 90, 143, 2, 52, 77, 239, 43, 247, 221, 12, 161, 118, 179, 224, 224, 141, 242, 87, 188, 167, 194, 189, 9, 2, 240]
```