### PR TITLE
✨ Make Trdelnik configurable to fix solana-test-validator's short startup timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 incremented upon a breaking change and the patch version will be incremented for features.
 
 ## [Unreleased]
+### Added
+- Trdelnik is now configurable. This requires `Trdelnik.toml` file to exist in the project's root directory - without this file the execution will fail. To solve this re-run `trdelnik init` or just create an empty `Trdelnik.toml` file in the project's root directory.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3663,6 +3663,7 @@ dependencies = [
  "fehler",
  "futures",
  "heck 0.4.0",
+ "lazy_static",
  "log",
  "pretty_assertions",
  "quote 1.0.18",

--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ async fn init_fixture() -> Fixture {
 
 - _We are exploring a new versions of Anchor, please make sure you only use the supported versions. We are working on it :muscle:_
 
+### Configuration
+
+The configuration variables can be edited in the `Trdelnik.toml` file that'll be generated in the root of the project.
+
+| Name                      | Default value | Description                                                                 |
+|---------------------------|---------------|-----------------------------------------------------------------------------|
+| `test.validator_startup_timeout` | 10 000        | Time to wait for the `solana-test-validator` in milliseconds before failure |
+
 ## Roadmap
 
 - [x] Q1/22 Trdelnik announcement at Solana Hacker House Prague

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -42,3 +42,4 @@ heck = { version = "0.4.0", default-features = false }
 toml = { version = "0.5.8", features = ["preserve_order"] }
 log = "0.4"
 rstest = "0.12.0"
+lazy_static = "1.4.0"

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -71,13 +71,13 @@ impl Client {
 
     /// Finds out if the Solana localnet is running.
     ///
-    /// Set `retry` to `true` when you want to wait until the localnet is running
-    /// or until 10 retries with 500ms delays are performed.
+    /// Set `retry` to `true` when you want to wait for up to 15 seconds until
+    /// the localnet is running (until 30 retries with 500ms delays are performed).
     pub async fn is_localnet_running(&self, retry: bool) -> bool {
         let dummy_pubkey = Pubkey::new_from_array([0; 32]);
         let rpc_client = self.anchor_client.program(dummy_pubkey).rpc();
         task::spawn_blocking(move || {
-            for _ in 0..(if retry { 10 } else { 1 }) {
+            for _ in 0..(if retry { 30 } else { 1 }) {
                 if rpc_client.get_health().is_ok() {
                     return true;
                 }

--- a/crates/client/src/config.rs
+++ b/crates/client/src/config.rs
@@ -1,0 +1,101 @@
+extern crate lazy_static;
+
+use anyhow::Context;
+use fehler::throw;
+use serde::Deserialize;
+use std::{env, fs, io, path::PathBuf};
+use thiserror::Error;
+
+pub const CARGO_TOML: &str = "Cargo.toml";
+pub const TRDELNIK_TOML: &str = "Trdelnik.toml";
+pub const ANCHOR_TOML: &str = "Anchor.toml";
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("invalid workspace")]
+    BadWorkspace,
+    #[error("{0:?}")]
+    Anyhow(#[from] anyhow::Error),
+    #[error("{0:?}")]
+    Io(#[from] io::Error),
+    #[error("{0:?}")]
+    Toml(#[from] toml::de::Error),
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Test {
+    pub validator_startup_timeout: u64,
+}
+
+#[derive(Default, Debug, Deserialize, Clone)]
+struct _Test {
+    #[serde(default)]
+    pub validator_startup_timeout: Option<u64>,
+}
+
+impl From<_Test> for Test {
+    fn from(_t: _Test) -> Self {
+        Self {
+            validator_startup_timeout: _t.validator_startup_timeout.unwrap_or(10_000),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Config {
+    pub test: Test,
+}
+
+#[derive(Default, Debug, Deserialize, Clone)]
+struct _Config {
+    #[serde(default)]
+    pub test: Option<_Test>,
+}
+
+impl From<_Config> for Config {
+    fn from(_c: _Config) -> Self {
+        Self {
+            test: _c.test.unwrap_or_default().into(),
+        }
+    }
+}
+
+impl Config {
+    pub fn new() -> Self {
+        let root = Config::discover_root().expect("failed to find the root folder");
+        let s = fs::read_to_string(root.join(TRDELNIK_TOML).as_path())
+            .expect("failed to read the Trdelnik config file");
+        let _config: _Config =
+            toml::from_str(&s).expect("failed to parse the Trdelnik config file");
+        _config.into()
+    }
+
+    /// Tries to find the root directory with the `Anchor.toml` file.
+    /// Throws an error when there is no directory with the `Anchor.toml` file
+    pub fn discover_root() -> Result<PathBuf, Error> {
+        let current_dir = env::current_dir()?;
+        let mut dir = Some(current_dir.as_path());
+        while let Some(cwd) = dir {
+            for file in std::fs::read_dir(cwd).with_context(|| {
+                format!("Error reading the directory with path: {}", cwd.display())
+            })? {
+                let path = file
+                    .with_context(|| {
+                        format!("Error reading the directory with path: {}", cwd.display())
+                    })?
+                    .path();
+                if let Some(filename) = path.file_name() {
+                    if filename.to_str() == Some(ANCHOR_TOML) {
+                        return Ok(PathBuf::from(cwd));
+                    }
+                }
+            }
+            dir = cwd.parent();
+        }
+        throw!(Error::BadWorkspace)
+    }
+}
+
+lazy_static::lazy_static! {
+    pub static ref CONFIG: Config = Config::new();
+}

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -23,6 +23,8 @@ pub use solana_transaction_status::EncodedConfirmedTransaction;
 pub use tokio;
 pub use trdelnik_test::trdelnik_test;
 
+mod config;
+
 mod client;
 pub use client::Client;
 pub use client::PrintableTransaction;

--- a/crates/client/src/templates/Trdelnik.toml.tmpl
+++ b/crates/client/src/templates/Trdelnik.toml.tmpl
@@ -1,0 +1,2 @@
+[test]
+validator_startup_timeout = 15000

--- a/crates/client/src/test_generator.rs
+++ b/crates/client/src/test_generator.rs
@@ -98,7 +98,7 @@ impl TestGenerator {
     /// finally it generates the `Cargo.toml` file. Crate is generated from `trdelnik-tests`
     /// template located in `client/src/templates`
     #[throws]
-    async fn generate_test_files(&self, root: &PathBuf) {
+    async fn generate_test_files(&self, root: &Path) {
         let workspace_path = root.join(TESTS_WORKSPACE);
         self.create_directory(&workspace_path, TESTS_WORKSPACE)
             .await?;

--- a/examples/escrow/Cargo.lock
+++ b/examples/escrow/Cargo.lock
@@ -1269,19 +1269,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
-name = "git2"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,18 +1576,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.13.4+1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,18 +1631,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
 dependencies = [
  "libsecp256k1-core",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3500,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "trdelnik-client"
-version = "0.1.0"
+version = "0.1.6"
 dependencies = [
  "anchor-client",
  "anyhow",
@@ -3534,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "trdelnik-test"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "darling",
  "proc-macro2 1.0.39",
@@ -3668,12 +3631,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3690,7 +3647,6 @@ dependencies = [
  "chrono",
  "enum-iterator",
  "getset",
- "git2",
  "rustversion",
  "thiserror",
 ]

--- a/examples/escrow/Cargo.lock
+++ b/examples/escrow/Cargo.lock
@@ -3474,6 +3474,7 @@ dependencies = [
  "fehler",
  "futures",
  "heck 0.4.0",
+ "lazy_static",
  "log",
  "quote 1.0.18",
  "rand 0.7.3",

--- a/examples/turnstile/Cargo.lock
+++ b/examples/turnstile/Cargo.lock
@@ -3487,6 +3487,7 @@ dependencies = [
  "fehler",
  "futures",
  "heck 0.4.0",
+ "lazy_static",
  "log",
  "quote 1.0.18",
  "rand 0.7.3",

--- a/examples/turnstile/Cargo.lock
+++ b/examples/turnstile/Cargo.lock
@@ -1250,19 +1250,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
-name = "git2"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e77a14ffc6ba4ad5188d6cf428894c4fcfda725326b37558f35bb677e712cec"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,18 +1557,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.13.3+1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24d36c3ac9b9996a2418d6bf428cc0bc5d1a814a84303fc60986088c5ed60de"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,18 +1612,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
 dependencies = [
  "libsecp256k1-core",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e7e15d7610cce1d9752e137625f14e61a28cd45929b6e12e47b50fe154ee2e"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3513,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "trdelnik-client"
-version = "0.1.0"
+version = "0.1.6"
 dependencies = [
  "anchor-client",
  "anyhow",
@@ -3547,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "trdelnik-test"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "darling",
  "proc-macro2 1.0.38",
@@ -3681,12 +3644,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3703,7 +3660,6 @@ dependencies = [
  "chrono",
  "enum-iterator",
  "getset",
- "git2",
  "rustversion",
  "thiserror",
 ]

--- a/examples/turnstile/Trdelnik.toml
+++ b/examples/turnstile/Trdelnik.toml
@@ -1,0 +1,2 @@
+[test]
+validator_startup_timeout = 15000


### PR DESCRIPTION
This ***fix*** should hopefully ***fix*** the issue #68.
The waiting time for the startup of `solana-test-validator` is increased to 15 ***(\*)*** seconds (30 retries) and the `solana-test-validator` process is killed (if running) after an unsuccessful start.

***(\*)*** this value can be configured in `Trdelnik.toml` (see edits in `README.md` and in `examples/turnstile/Trdelnik.toml`