### PR TITLE
🧑‍💻 trait Default for Client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,4 @@ num-traits                      = "0.2.14"
 proc-macro2                     = { version = "1.0.66", default-features = false }
 darling                         = "0.13.1"
 clap                            = { version = "4.3.19", features = ["derive"] }
+shellexpand                     = "3.1.0"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -49,3 +49,4 @@ honggfuzz                    = { version = "0.5.55", optional = true }
 arbitrary                    = { version = "1.3.0", optional = true }
 solana-program-test          = { version = "1.16.9", optional = true}
 quinn-proto                  = { version = "0.9.4", optional = true}
+shellexpand                  = { workspace = true }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -56,7 +56,7 @@ impl Default for Client {
             payer: payer.clone(),
             anchor_client: AnchorClient::new_with_options(
                 Cluster::Localnet,
-                Rc::new(payer.clone()),
+                Rc::new(payer),
                 CommitmentConfig::confirmed(),
             ),
         }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -12,6 +12,7 @@ use anchor_client::{
         instruction::Instruction,
         loader_instruction,
         pubkey::Pubkey,
+        signature::read_keypair_file,
         signer::{keypair::Keypair, Signer},
         system_instruction,
         transaction::Transaction,
@@ -36,6 +37,7 @@ use std::{thread::sleep, time::Duration};
 // https://github.com/project-serum/anchor/pull/1307#issuecomment-1022592683
 
 const RETRY_LOCALNET_EVERY_MILLIS: u64 = 500;
+const DEFAULT_KEYPAIR_PATH: &str = "~/.config/solana/id.json";
 
 type Payer = Rc<Keypair>;
 
@@ -43,6 +45,22 @@ type Payer = Rc<Keypair>;
 pub struct Client {
     payer: Keypair,
     anchor_client: AnchorClient<Payer>,
+}
+
+/// Implement Default trait for Client, which reads keypair from default path for `solana-keygen new`
+impl Default for Client {
+    fn default() -> Self {
+        let payer = read_keypair_file(&*shellexpand::tilde(DEFAULT_KEYPAIR_PATH))
+            .unwrap_or_else(|_| panic!("Default keypair {DEFAULT_KEYPAIR_PATH} not found."));
+        Self {
+            payer: payer.clone(),
+            anchor_client: AnchorClient::new_with_options(
+                Cluster::Localnet,
+                Rc::new(payer.clone()),
+                CommitmentConfig::confirmed(),
+            ),
+        }
+    }
 }
 
 impl Client {

--- a/crates/client/src/templates/trdelnik-tests/test.rs
+++ b/crates/client/src/templates/trdelnik-tests/test.rs
@@ -28,7 +28,7 @@ struct Fixture {
 impl Fixture {
     fn new() -> Self {
         Fixture {
-            client: Client::new(system_keypair(0)),
+            client: Client::default(),
             program: anchor_keypair("###PROGRAM_NAME###").unwrap(),
             state: keypair(42),
         }

--- a/examples/escrow/trdelnik-tests/tests/test.rs
+++ b/examples/escrow/trdelnik-tests/tests/test.rs
@@ -199,6 +199,9 @@ struct Fixture {
 impl Fixture {
     fn new() -> Self {
         Fixture {
+            // We use the hardcoded system_keypair(0).
+            // However the default option in the test template is now to use implementation of trait Default
+            // for Client which will read keypair from "~/.config/solana/id.json" - (default path for `solana-keygen new`)
             client: Client::new(system_keypair(0)),
 
             // We use the hardcoded program_keypair(1) to ensure users can run these tests without the

--- a/examples/turnstile/trdelnik-tests/tests/test.rs
+++ b/examples/turnstile/trdelnik-tests/tests/test.rs
@@ -7,6 +7,9 @@ use trdelnik_client::{anyhow::Result, *};
 async fn init_fixture() -> Fixture {
     // create a test fixture
     let fixture = Fixture {
+        // We use the hardcoded system_keypair(0).
+        // However the default option in the test template is now to use implementation of trait Default
+        // for Client which will read keypair from "~/.config/solana/id.json" - (default path for `solana-keygen new`)
         client: Client::new(system_keypair(0)),
 
         // We use the hardcoded program_keypair(1) to ensure users can run these tests without the


### PR DESCRIPTION
Implemented Default trait for Client, which reads keypair from default path for `solana-keygen new` - no need for hardcoded keypair for Client. 