### PR TITLE
Feat/toml params for fuzzer

### DIFF
--- a/crates/cli/src/command/fuzz.rs
+++ b/crates/cli/src/command/fuzz.rs
@@ -47,7 +47,7 @@ pub async fn fuzz(root: Option<String>, subcmd: FuzzCommand) {
         }
     };
 
-    let mut commander = Commander::with_root(root.clone());
+    let commander = Commander::with_root(root.clone());
 
     match subcmd {
         FuzzCommand::Run {

--- a/crates/cli/src/command/fuzz.rs
+++ b/crates/cli/src/command/fuzz.rs
@@ -47,7 +47,7 @@ pub async fn fuzz(root: Option<String>, subcmd: FuzzCommand) {
         }
     };
 
-    let commander = Commander::with_root(root.clone());
+    let mut commander = Commander::with_root(root.clone());
 
     match subcmd {
         FuzzCommand::Run {

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1,4 +1,4 @@
-use crate::{config::CONFIG, Reader, TempClone};
+use crate::{config::Config, Reader, TempClone};
 use anchor_client::{
     anchor_lang::{
         prelude::System, solana_program::program_pack::Pack, AccountDeserialize, Id,
@@ -43,6 +43,7 @@ type Payer = Rc<Keypair>;
 pub struct Client {
     payer: Keypair,
     anchor_client: AnchorClient<Payer>,
+    config: Config,
 }
 
 impl Client {
@@ -55,6 +56,7 @@ impl Client {
                 Rc::new(payer),
                 CommitmentConfig::confirmed(),
             ),
+            config: Config::new(),
         }
     }
 
@@ -85,7 +87,7 @@ impl Client {
             .async_rpc();
 
         for _ in 0..(if retry {
-            CONFIG.test.validator_startup_timeout / RETRY_LOCALNET_EVERY_MILLIS
+            self.config.test.validator_startup_timeout / RETRY_LOCALNET_EVERY_MILLIS
         } else {
             1
         }) {

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -43,7 +43,6 @@ type Payer = Rc<Keypair>;
 pub struct Client {
     payer: Keypair,
     anchor_client: AnchorClient<Payer>,
-    config: Config,
 }
 
 impl Client {
@@ -56,7 +55,6 @@ impl Client {
                 Rc::new(payer),
                 CommitmentConfig::confirmed(),
             ),
-            config: Config::new(),
         }
     }
 
@@ -80,6 +78,8 @@ impl Client {
     /// Set `retry` to `true` when you want to wait for up to 15 seconds until
     /// the localnet is running (until 30 retries with 500ms delays are performed).
     pub async fn is_localnet_running(&self, retry: bool) -> bool {
+        let config = Config::new();
+
         let rpc_client = self
             .anchor_client
             .program(System::id())
@@ -87,7 +87,7 @@ impl Client {
             .async_rpc();
 
         for _ in 0..(if retry {
-            self.config.test.validator_startup_timeout / RETRY_LOCALNET_EVERY_MILLIS
+            config.test.validator_startup_timeout / RETRY_LOCALNET_EVERY_MILLIS
         } else {
             1
         }) {

--- a/crates/client/src/commander.rs
+++ b/crates/client/src/commander.rs
@@ -154,13 +154,10 @@ impl Commander {
     /// Runs fuzzer on the given target.
     #[throws]
     pub async fn run_fuzzer(&self, target: String) {
-        let mut config = Config::new();
+        let config = Config::new();
 
-        if let Ok(var) = std::env::var("HFUZZ_RUN_ARGS") {
-            config.merge_with_cli(&var)
-        }
-
-        let env_variables = config.get_env_variables();
+        let hfuzz_run_args = std::env::var("HFUZZ_RUN_ARGS").unwrap_or_default();
+        let env_variable = config.get_env_variable(hfuzz_run_args);
 
         let cur_dir = Path::new(&self.root.to_string()).join(TESTS_WORKSPACE);
         if !cur_dir.try_exists()? {
@@ -168,7 +165,7 @@ impl Commander {
         }
 
         let mut child = Command::new("cargo")
-            .env("HFUZZ_RUN_ARGS", env_variables)
+            .env("HFUZZ_RUN_ARGS", env_variable)
             .current_dir(cur_dir)
             .arg("hfuzz")
             .arg("run")

--- a/crates/client/src/commander.rs
+++ b/crates/client/src/commander.rs
@@ -100,7 +100,6 @@ impl LocalnetHandle {
 /// run tests and do other useful operations.
 pub struct Commander {
     root: Cow<'static, str>,
-    config: Config,
 }
 
 impl Commander {
@@ -108,16 +107,12 @@ impl Commander {
     pub fn new() -> Self {
         Self {
             root: "../../".into(),
-            config: Config::new(),
         }
     }
 
     /// Creates a new `Commander` instance with the provided `root`.
     pub fn with_root(root: impl Into<Cow<'static, str>>) -> Self {
-        Self {
-            root: root.into(),
-            config: Config::new(),
-        }
+        Self { root: root.into() }
     }
 
     /// Builds programs (smart contracts).
@@ -159,18 +154,19 @@ impl Commander {
     /// Runs fuzzer on the given target.
     #[throws]
     pub async fn run_fuzzer(&mut self, target: String) {
+        let mut config = Config::new();
+
         if let Ok(var) = std::env::var("HFUZZ_RUN_ARGS") {
-            self.config.merge_with_cli(&var)
+            config.merge_with_cli(&var)
         }
 
-        let env_variables = self.config.get_env_variables();
+        let env_variables = config.get_env_variables();
 
         let cur_dir = Path::new(&self.root.to_string()).join(TESTS_WORKSPACE);
         if !cur_dir.try_exists()? {
             throw!(Error::NotInitialized);
         }
 
-        println!("{:?}", env_variables);
         let mut child = Command::new("cargo")
             .env("HFUZZ_RUN_ARGS", env_variables)
             .current_dir(cur_dir)

--- a/crates/client/src/commander.rs
+++ b/crates/client/src/commander.rs
@@ -157,7 +157,7 @@ impl Commander {
         let config = Config::new();
 
         let hfuzz_run_args = std::env::var("HFUZZ_RUN_ARGS").unwrap_or_default();
-        let env_variable = config.get_env_variable(hfuzz_run_args);
+        let fuzz_args = config.get_fuzz_args(hfuzz_run_args);
 
         let cur_dir = Path::new(&self.root.to_string()).join(TESTS_WORKSPACE);
         if !cur_dir.try_exists()? {
@@ -165,7 +165,7 @@ impl Commander {
         }
 
         let mut child = Command::new("cargo")
-            .env("HFUZZ_RUN_ARGS", env_variable)
+            .env("HFUZZ_RUN_ARGS", fuzz_args)
             .current_dir(cur_dir)
             .arg("hfuzz")
             .arg("run")

--- a/crates/client/src/commander.rs
+++ b/crates/client/src/commander.rs
@@ -154,13 +154,9 @@ impl Commander {
     /// Runs fuzzer on the given target.
     #[throws]
     pub async fn run_fuzzer(&self, target: String) {
-        // get variables from Toml
-        let toml_fuzz_env = CONFIG.get_fuzz_env_variable();
-        // check if variables in CLI, and give them precedence
-        // TODO try to merge them or give precedence not just replace
-        let env_var = match std::env::var("HFUZZ_RUN_ARGS") {
-            Ok(var) => var,
-            Err(_) => toml_fuzz_env,
+        let fuzz_env = match std::env::var("HFUZZ_RUN_ARGS") {
+            Ok(var) => CONFIG.get_fuzz_env_variable(&var),
+            Err(_) => CONFIG.get_fuzz_env_variable(&String::new()),
         };
 
         let cur_dir = Path::new(&self.root.to_string()).join(TESTS_WORKSPACE);
@@ -168,7 +164,7 @@ impl Commander {
             throw!(Error::NotInitialized);
         }
         let mut child = Command::new("cargo")
-            .env("HFUZZ_RUN_ARGS", env_var)
+            .env("HFUZZ_RUN_ARGS", fuzz_env)
             .current_dir(cur_dir)
             .arg("hfuzz")
             .arg("run")

--- a/crates/client/src/commander.rs
+++ b/crates/client/src/commander.rs
@@ -153,7 +153,7 @@ impl Commander {
     }
     /// Runs fuzzer on the given target.
     #[throws]
-    pub async fn run_fuzzer(&mut self, target: String) {
+    pub async fn run_fuzzer(&self, target: String) {
         let mut config = Config::new();
 
         if let Ok(var) = std::env::var("HFUZZ_RUN_ARGS") {

--- a/crates/client/src/config.rs
+++ b/crates/client/src/config.rs
@@ -1,5 +1,3 @@
-extern crate lazy_static;
-
 use anyhow::Context;
 use fehler::throw;
 use serde::Deserialize;

--- a/crates/client/src/config.rs
+++ b/crates/client/src/config.rs
@@ -27,10 +27,46 @@ pub struct Test {
     pub validator_startup_timeout: u64,
 }
 
+#[derive(Debug, Deserialize, Clone)]
+pub struct Fuzz {
+    /// Timeout in seconds (default: 10)
+    /// -t
+    pub timeout: (char, u16),
+    /// Number of fuzzing iterations (default: 0 [no limit])
+    /// -N
+    pub iterations: (char, u64),
+    /// Don't close children's stdin, stdout, stderr; can be noisy
+    /// -Q
+    pub keep_output: (char, bool),
+    /// Disable ANSI console; use simple log output
+    /// -v
+    pub verbose: (char, bool),
+}
+
 #[derive(Default, Debug, Deserialize, Clone)]
 struct _Test {
     #[serde(default)]
     pub validator_startup_timeout: Option<u64>,
+}
+
+#[derive(Default, Debug, Deserialize, Clone)]
+struct _Fuzz {
+    #[serde(default)]
+    /// Timeout in seconds (default: 10)
+    /// -t
+    pub timeout: Option<u16>,
+    #[serde(default)]
+    /// Number of fuzzing iterations (default: 0 [no limit])
+    /// -N
+    pub iterations: Option<u64>,
+    #[serde(default)]
+    /// Don't close children's stdin, stdout, stderr; can be noisy
+    /// -Q
+    pub keep_output: Option<bool>,
+    #[serde(default)]
+    /// Disable ANSI console; use simple log output
+    /// -v
+    pub verbose: Option<bool>,
 }
 
 impl From<_Test> for Test {
@@ -41,21 +77,36 @@ impl From<_Test> for Test {
     }
 }
 
+impl From<_Fuzz> for Fuzz {
+    fn from(_f: _Fuzz) -> Self {
+        Self {
+            timeout: ('t', _f.timeout.unwrap_or(10)),
+            iterations: ('N', _f.iterations.unwrap_or(0)),
+            keep_output: ('Q', _f.keep_output.unwrap_or(false)),
+            verbose: ('v', _f.verbose.unwrap_or(false)),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
     pub test: Test,
+    pub fuzz: Fuzz,
 }
 
 #[derive(Default, Debug, Deserialize, Clone)]
 struct _Config {
     #[serde(default)]
     pub test: Option<_Test>,
+    #[serde(default)]
+    pub fuzz: Option<_Fuzz>,
 }
 
 impl From<_Config> for Config {
     fn from(_c: _Config) -> Self {
         Self {
             test: _c.test.unwrap_or_default().into(),
+            fuzz: _c.fuzz.unwrap_or_default().into(),
         }
     }
 }
@@ -93,6 +144,29 @@ impl Config {
             dir = cwd.parent();
         }
         throw!(Error::BadWorkspace)
+    }
+    pub fn get_fuzz_env_variable(&self) -> String {
+        let iterations = &self.fuzz.iterations;
+        let timeout = &self.fuzz.timeout;
+        let verbose = &self.fuzz.verbose;
+        let keep_out = &self.fuzz.keep_output;
+
+        let mut variable_string = format!(
+            "-{} {} -{} {}",
+            iterations.0, iterations.1, timeout.0, timeout.1,
+        );
+
+        variable_string = match verbose.1 {
+            true => format!("{} -{}", variable_string, verbose.0),
+            false => variable_string,
+        };
+
+        variable_string = match keep_out.1 {
+            true => format!("{} -{}", variable_string, keep_out.0),
+            false => variable_string,
+        };
+
+        variable_string
     }
 }
 

--- a/crates/client/src/templates/Trdelnik.toml.tmpl
+++ b/crates/client/src/templates/Trdelnik.toml.tmpl
@@ -2,7 +2,8 @@
 validator_startup_timeout = 15000
 
 [fuzz]
-# iterations = 587
-# timeout = 25
-# keep_out = true
-# verbose = false
+# iterations = 587 # -N
+# timeout = 25 # -t
+# keep_out = true # -Q
+# verbose = false # -v
+# exit_upon_crash = false # --exit_upon_crash

--- a/crates/client/src/templates/Trdelnik.toml.tmpl
+++ b/crates/client/src/templates/Trdelnik.toml.tmpl
@@ -1,9 +1,11 @@
 [test]
 validator_startup_timeout = 15000
 
-[fuzz]
-# iterations = 587 # -N
-# timeout = 25 # -t
-# keep_out = true # -Q
-# verbose = false # -v
-# exit_upon_crash = false # --exit_upon_crash
+
+# set for default values
+[hfuzz_run_args]
+iterations = 0
+timeout = 10
+keep_output = false
+verbose = false
+exit_upon_crash = false

--- a/crates/client/src/templates/Trdelnik.toml.tmpl
+++ b/crates/client/src/templates/Trdelnik.toml.tmpl
@@ -3,9 +3,9 @@ validator_startup_timeout = 15000
 
 
 # set for default values
-[hfuzz_run_args]
-iterations = 0
+[fuzz]
 timeout = 10
+iterations = 0
 keep_output = false
 verbose = false
 exit_upon_crash = false

--- a/crates/client/src/templates/Trdelnik.toml.tmpl
+++ b/crates/client/src/templates/Trdelnik.toml.tmpl
@@ -1,2 +1,8 @@
 [test]
 validator_startup_timeout = 15000
+
+[fuzz]
+# iterations = 587
+# timeout = 25
+# keep_out = true
+# verbose = false

--- a/examples/fuzzer/Trdelnik.toml
+++ b/examples/fuzzer/Trdelnik.toml
@@ -1,9 +1,9 @@
 [test]
 validator_startup_timeout = 15000
 
-[hfuzz_run_args]
+[fuzz]
 iterations = 500
 timeout = 25
 keep_output = false
 verbose = false
-exit_upon_crash = false # --exit_upon_crash
+exit_upon_crash = true

--- a/examples/fuzzer/Trdelnik.toml
+++ b/examples/fuzzer/Trdelnik.toml
@@ -1,8 +1,9 @@
 [test]
 validator_startup_timeout = 15000
 
-[fuzz]
-# iterations = 587
-# timeout = 25
-# keep_out = true
-# verbose = false
+[hfuzz_run_args]
+iterations = 500
+timeout = 25
+keep_output = false
+verbose = false
+exit_upon_crash = false # --exit_upon_crash

--- a/examples/fuzzer/Trdelnik.toml
+++ b/examples/fuzzer/Trdelnik.toml
@@ -1,2 +1,8 @@
 [test]
 validator_startup_timeout = 15000
+
+[fuzz]
+# iterations = 587
+# timeout = 25
+# keep_out = true
+# verbose = false


### PR DESCRIPTION
Instead of using the HFUZZ_RUN_ARGS environment variable all the time, this feature allows us to pass the HFUZZ_RUN_ARGS flags within the Trdelnik.toml file. It also supports precedence from the command line interface (CLI), so if we specify a timeout within the Toml file as 500 seconds, it can still be overwritten by CLI input like HFUZZ_RUN_ARGS='-t 33'. Furthermore, it also supports merging from the CLI, so if the CLI's HFUZZ_RUN_ARGS contains flags that are not supported within the configuration file, they will simply be merged.