### PR TITLE
Feat/fuzz pkey to acc

### DIFF
--- a/crates/client/src/fuzzer/fuzzer_generator.rs
+++ b/crates/client/src/fuzzer/fuzzer_generator.rs
@@ -53,14 +53,20 @@ pub fn generate_source_code(idl: &Idl) -> String {
                             .iter()
                             .map(|(name, ty)| {
                                 let name_ident = format_ident!("{name}");
-                                let ty = parse_str(ty).unwrap();
+                                let ty = parse_str(ty).expect("Unable To parse argument type");
                                 let ty: syn::Type = match &ty {
                                     syn::Type::Path(tp) => {
-                                        let last_type =
-                                            &tp.path.segments.last().unwrap().ident.to_string();
-                                        if last_type == "Pubkey" {
-                                            let t: syn::Type = parse_str("AccountId").unwrap();
-                                            t
+                                        if &tp
+                                            .path
+                                            .segments
+                                            .last()
+                                            .expect("Unable To obtain last type")
+                                            .ident
+                                            .to_string()
+                                            == "Pubkey"
+                                        {
+                                            parse_str("AccountId")
+                                                .expect("Unable To parse AccountId")
                                         } else {
                                             ty
                                         }

--- a/crates/client/src/fuzzer/fuzzer_generator.rs
+++ b/crates/client/src/fuzzer/fuzzer_generator.rs
@@ -53,11 +53,10 @@ pub fn generate_source_code(idl: &Idl) -> String {
                             .iter()
                             .map(|(name, ty)| {
                                 let name_ident = format_ident!("{name}");
-                                // the option ":: Pubkey"is for "anchor_lang::pubkey::Pubkey", that looks
-                                // like "anchor_lang :: pubkey :: Pubkey"
-                                let ty: syn::Type = if ty.ends_with("Pubkey")
-                                    || ty.ends_with("::Pubkey")
-                                    || ty.ends_with(":: Pubkey")
+                                // Replace Pubkey type by AccountId, so the fuzzer will generate only Account indices
+                                // a not always unique Pubkeys
+                                let ty: syn::Type = if ty == "Pubkey"
+                                    || ty.replace(' ', "").ends_with("::Pubkey")
                                 {
                                     parse_str("AccountId").expect("Unable to parse AccountId")
                                 } else {

--- a/crates/client/src/fuzzer/fuzzer_generator.rs
+++ b/crates/client/src/fuzzer/fuzzer_generator.rs
@@ -53,25 +53,15 @@ pub fn generate_source_code(idl: &Idl) -> String {
                             .iter()
                             .map(|(name, ty)| {
                                 let name_ident = format_ident!("{name}");
-                                let ty = parse_str(ty).expect("Unable To parse argument type");
-                                let ty: syn::Type = match &ty {
-                                    syn::Type::Path(tp) => {
-                                        if &tp
-                                            .path
-                                            .segments
-                                            .last()
-                                            .expect("Unable To obtain last type")
-                                            .ident
-                                            .to_string()
-                                            == "Pubkey"
-                                        {
-                                            parse_str("AccountId")
-                                                .expect("Unable To parse AccountId")
-                                        } else {
-                                            ty
-                                        }
-                                    }
-                                    _ => ty,
+                                // the option ":: Pubkey"is for "anchor_lang::pubkey::Pubkey", that looks
+                                // like "anchor_lang :: pubkey :: Pubkey"
+                                let ty: syn::Type = if ty.ends_with("Pubkey")
+                                    || ty.ends_with("::Pubkey")
+                                    || ty.ends_with(":: Pubkey")
+                                {
+                                    parse_str("AccountId").expect("Unable to parse AccountId")
+                                } else {
+                                    parse_str(ty).expect("Unable to parse ty")
                                 };
                                 let parameter: syn::FnArg = parse_quote!(#name_ident: #ty);
                                 parameter

--- a/crates/client/src/fuzzer/fuzzer_generator.rs
+++ b/crates/client/src/fuzzer/fuzzer_generator.rs
@@ -221,6 +221,7 @@ pub fn generate_source_code(idl: &Idl) -> String {
 
             let fuzzer_module: syn::ItemMod = parse_quote! {
                 pub mod #fuzz_instructions_module_name {
+                    use trdelnik_client::fuzzing::*;
                     use crate::accounts_snapshots::*;
 
                     #[derive(Arbitrary, Clone, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]

--- a/crates/client/tests/test_data/expanded_source_codes/expanded_fuzz_example3.rs
+++ b/crates/client/tests/test_data/expanded_source_codes/expanded_fuzz_example3.rs
@@ -3493,6 +3493,7 @@ mod __private {
                 .map_err(|_| anchor_lang::error::ErrorCode::InstructionDidNotDeserialize)?;
             let instruction::InitVesting {
                 recipient,
+                _recipient,
                 amount,
                 start_at,
                 end_at,
@@ -3516,6 +3517,7 @@ mod __private {
                     __bumps,
                 ),
                 recipient,
+                _recipient,
                 amount,
                 start_at,
                 end_at,
@@ -3558,6 +3560,7 @@ pub mod fuzz_example3 {
     pub fn init_vesting(
         ctx: Context<InitVesting>,
         recipient: Pubkey,
+        _recipient: anchor_lang::prelude::Pubkey,
         amount: u64,
         start_at: u64,
         end_at: u64,
@@ -3580,6 +3583,7 @@ pub mod instruction {
     #[doc = r" Instruction."]
     pub struct InitVesting {
         pub recipient: Pubkey,
+        pub _recipient: anchor_lang::prelude::Pubkey,
         pub amount: u64,
         pub start_at: u64,
         pub end_at: u64,
@@ -3588,6 +3592,7 @@ pub mod instruction {
     impl borsh::ser::BorshSerialize for InitVesting
     where
         Pubkey: borsh::ser::BorshSerialize,
+        anchor_lang::prelude::Pubkey: borsh::ser::BorshSerialize,
         u64: borsh::ser::BorshSerialize,
         u64: borsh::ser::BorshSerialize,
         u64: borsh::ser::BorshSerialize,
@@ -3598,6 +3603,7 @@ pub mod instruction {
             writer: &mut W,
         ) -> ::core::result::Result<(), borsh::maybestd::io::Error> {
             borsh::BorshSerialize::serialize(&self.recipient, writer)?;
+            borsh::BorshSerialize::serialize(&self._recipient, writer)?;
             borsh::BorshSerialize::serialize(&self.amount, writer)?;
             borsh::BorshSerialize::serialize(&self.start_at, writer)?;
             borsh::BorshSerialize::serialize(&self.end_at, writer)?;
@@ -3608,6 +3614,7 @@ pub mod instruction {
     impl borsh::de::BorshDeserialize for InitVesting
     where
         Pubkey: borsh::BorshDeserialize,
+        anchor_lang::prelude::Pubkey: borsh::BorshDeserialize,
         u64: borsh::BorshDeserialize,
         u64: borsh::BorshDeserialize,
         u64: borsh::BorshDeserialize,
@@ -3618,6 +3625,7 @@ pub mod instruction {
         ) -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
             Ok(Self {
                 recipient: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                _recipient: borsh::BorshDeserialize::deserialize_reader(reader)?,
                 amount: borsh::BorshDeserialize::deserialize_reader(reader)?,
                 start_at: borsh::BorshDeserialize::deserialize_reader(reader)?,
                 end_at: borsh::BorshDeserialize::deserialize_reader(reader)?,

--- a/crates/client/tests/test_data/expanded_source_codes/expanded_fuzz_example3.rs
+++ b/crates/client/tests/test_data/expanded_source_codes/expanded_fuzz_example3.rs
@@ -3492,7 +3492,7 @@ mod __private {
             let ix = instruction::InitVesting::deserialize(&mut &__ix_data[..])
                 .map_err(|_| anchor_lang::error::ErrorCode::InstructionDidNotDeserialize)?;
             let instruction::InitVesting {
-                i_recipient,
+                recipient,
                 amount,
                 start_at,
                 end_at,
@@ -3515,7 +3515,7 @@ mod __private {
                     __remaining_accounts,
                     __bumps,
                 ),
-                i_recipient,
+                recipient,
                 amount,
                 start_at,
                 end_at,
@@ -3557,13 +3557,13 @@ pub mod fuzz_example3 {
     use super::*;
     pub fn init_vesting(
         ctx: Context<InitVesting>,
-        i_recipient: Pubkey,
+        recipient: Pubkey,
         amount: u64,
         start_at: u64,
         end_at: u64,
         interval: u64,
     ) -> Result<()> {
-        _init_vesting(ctx, i_recipient, amount, start_at, end_at, interval)
+        _init_vesting(ctx, recipient, amount, start_at, end_at, interval)
     }
     pub fn withdraw_unlocked(ctx: Context<WithdrawUnlocked>) -> Result<()> {
         _withdraw_unlocked(ctx)
@@ -3579,7 +3579,7 @@ pub mod instruction {
     use super::*;
     #[doc = r" Instruction."]
     pub struct InitVesting {
-        pub i_recipient: Pubkey,
+        pub recipient: Pubkey,
         pub amount: u64,
         pub start_at: u64,
         pub end_at: u64,
@@ -3597,7 +3597,7 @@ pub mod instruction {
             &self,
             writer: &mut W,
         ) -> ::core::result::Result<(), borsh::maybestd::io::Error> {
-            borsh::BorshSerialize::serialize(&self.i_recipient, writer)?;
+            borsh::BorshSerialize::serialize(&self.recipient, writer)?;
             borsh::BorshSerialize::serialize(&self.amount, writer)?;
             borsh::BorshSerialize::serialize(&self.start_at, writer)?;
             borsh::BorshSerialize::serialize(&self.end_at, writer)?;
@@ -3617,7 +3617,7 @@ pub mod instruction {
             reader: &mut R,
         ) -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
             Ok(Self {
-                i_recipient: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                recipient: borsh::BorshDeserialize::deserialize_reader(reader)?,
                 amount: borsh::BorshDeserialize::deserialize_reader(reader)?,
                 start_at: borsh::BorshDeserialize::deserialize_reader(reader)?,
                 end_at: borsh::BorshDeserialize::deserialize_reader(reader)?,

--- a/crates/client/tests/test_data/expanded_source_codes/expanded_fuzz_example3.rs
+++ b/crates/client/tests/test_data/expanded_source_codes/expanded_fuzz_example3.rs
@@ -108,7 +108,7 @@ mod instructions {
                         error_msg: VestingError::InvalidAmount.to_string(),
                         error_origin: Some(anchor_lang::error::ErrorOrigin::Source(
                             anchor_lang::error::Source {
-                                filename: "programs/fuzz_example3/src/instructions/initialize.rs",
+                                filename: "src/instructions/initialize.rs",
                                 line: 18u32,
                             },
                         )),
@@ -124,7 +124,7 @@ mod instructions {
                         error_msg: VestingError::InvalidTimeRange.to_string(),
                         error_origin: Some(anchor_lang::error::ErrorOrigin::Source(
                             anchor_lang::error::Source {
-                                filename: "programs/fuzz_example3/src/instructions/initialize.rs",
+                                filename: "src/instructions/initialize.rs",
                                 line: 20u32,
                             },
                         )),
@@ -140,7 +140,7 @@ mod instructions {
                         error_msg: VestingError::InvalidInterval.to_string(),
                         error_origin: Some(anchor_lang::error::ErrorOrigin::Source(
                             anchor_lang::error::Source {
-                                filename: "programs/fuzz_example3/src/instructions/initialize.rs",
+                                filename: "src/instructions/initialize.rs",
                                 line: 22u32,
                             },
                         )),
@@ -156,7 +156,7 @@ mod instructions {
                         error_msg: VestingError::InvalidInterval.to_string(),
                         error_origin: Some(anchor_lang::error::ErrorOrigin::Source(
                             anchor_lang::error::Source {
-                                filename: "programs/fuzz_example3/src/instructions/initialize.rs",
+                                filename: "src/instructions/initialize.rs",
                                 line: 23u32,
                             },
                         )),
@@ -365,7 +365,7 @@ mod instructions {
                                                                        error_code_number: anchor_lang::error::ErrorCode::TryingToInitPayerAsProgramAccount.into(),
                                                                        error_msg: anchor_lang::error::ErrorCode::TryingToInitPayerAsProgramAccount.to_string(),
                                                                        error_origin: Some(anchor_lang::error::ErrorOrigin::Source(anchor_lang::error::Source {
-                                                                                   filename: "programs/fuzz_example3/src/instructions/initialize.rs",
+                                                                                   filename: "src/instructions/initialize.rs",
                                                                                    line: 64u32,
                                                                                })),
                                                                        compared_values: None,
@@ -1364,7 +1364,7 @@ pub mod state {
                             .to_string(),
                         error_origin: Some(anchor_lang::error::ErrorOrigin::Source(
                             anchor_lang::error::Source {
-                                filename: "programs/fuzz_example3/src/state.rs",
+                                filename: "src/state.rs",
                                 line: 3u32,
                             },
                         )),
@@ -1764,7 +1764,7 @@ mod __private {
                                 .to_string(),
                             error_origin: Some(anchor_lang::error::ErrorOrigin::Source(
                                 anchor_lang::error::Source {
-                                    filename: "programs/fuzz_example3/src/lib.rs",
+                                    filename: "src/lib.rs",
                                     line: 11u32,
                                 },
                             )),
@@ -3424,7 +3424,7 @@ mod __private {
                         error_msg: anchor_lang::error::ErrorCode::RequireEqViolated.to_string(),
                         error_origin: Some(anchor_lang::error::ErrorOrigin::Source(
                             anchor_lang::error::Source {
-                                filename: "programs/fuzz_example3/src/lib.rs",
+                                filename: "src/lib.rs",
                                 line: 11u32,
                             },
                         )),
@@ -3466,7 +3466,7 @@ mod __private {
                         error_msg: anchor_lang::error::ErrorCode::RequireGteViolated.to_string(),
                         error_origin: Some(anchor_lang::error::ErrorOrigin::Source(
                             anchor_lang::error::Source {
-                                filename: "programs/fuzz_example3/src/lib.rs",
+                                filename: "src/lib.rs",
                                 line: 11u32,
                             },
                         )),
@@ -3492,7 +3492,7 @@ mod __private {
             let ix = instruction::InitVesting::deserialize(&mut &__ix_data[..])
                 .map_err(|_| anchor_lang::error::ErrorCode::InstructionDidNotDeserialize)?;
             let instruction::InitVesting {
-                recipient,
+                i_recipient,
                 amount,
                 start_at,
                 end_at,
@@ -3515,7 +3515,7 @@ mod __private {
                     __remaining_accounts,
                     __bumps,
                 ),
-                recipient,
+                i_recipient,
                 amount,
                 start_at,
                 end_at,
@@ -3557,13 +3557,13 @@ pub mod fuzz_example3 {
     use super::*;
     pub fn init_vesting(
         ctx: Context<InitVesting>,
-        recipient: Pubkey,
+        i_recipient: Pubkey,
         amount: u64,
         start_at: u64,
         end_at: u64,
         interval: u64,
     ) -> Result<()> {
-        _init_vesting(ctx, recipient, amount, start_at, end_at, interval)
+        _init_vesting(ctx, i_recipient, amount, start_at, end_at, interval)
     }
     pub fn withdraw_unlocked(ctx: Context<WithdrawUnlocked>) -> Result<()> {
         _withdraw_unlocked(ctx)
@@ -3579,7 +3579,7 @@ pub mod instruction {
     use super::*;
     #[doc = r" Instruction."]
     pub struct InitVesting {
-        pub recipient: Pubkey,
+        pub i_recipient: Pubkey,
         pub amount: u64,
         pub start_at: u64,
         pub end_at: u64,
@@ -3597,7 +3597,7 @@ pub mod instruction {
             &self,
             writer: &mut W,
         ) -> ::core::result::Result<(), borsh::maybestd::io::Error> {
-            borsh::BorshSerialize::serialize(&self.recipient, writer)?;
+            borsh::BorshSerialize::serialize(&self.i_recipient, writer)?;
             borsh::BorshSerialize::serialize(&self.amount, writer)?;
             borsh::BorshSerialize::serialize(&self.start_at, writer)?;
             borsh::BorshSerialize::serialize(&self.end_at, writer)?;
@@ -3617,7 +3617,7 @@ pub mod instruction {
             reader: &mut R,
         ) -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
             Ok(Self {
-                recipient: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                i_recipient: borsh::BorshDeserialize::deserialize_reader(reader)?,
                 amount: borsh::BorshDeserialize::deserialize_reader(reader)?,
                 start_at: borsh::BorshDeserialize::deserialize_reader(reader)?,
                 end_at: borsh::BorshDeserialize::deserialize_reader(reader)?,

--- a/crates/client/tests/test_data/expected_source_codes/expected_fuzz_instructions.rs
+++ b/crates/client/tests/test_data/expected_source_codes/expected_fuzz_instructions.rs
@@ -23,7 +23,7 @@ pub mod fuzz_example3_fuzz_instructions {
     }
     #[derive(Arbitrary, Clone)]
     pub struct InitVestingData {
-        pub i_recipient: AccountId,
+        pub recipient: AccountId,
         pub amount: u64,
         pub start_at: u64,
         pub end_at: u64,
@@ -57,7 +57,7 @@ pub mod fuzz_example3_fuzz_instructions {
             _fuzz_accounts: &mut FuzzAccounts,
         ) -> Result<Self::IxData, FuzzingError> {
             let data = fuzz_example3::instruction::InitVesting {
-                i_recipient: todo!(),
+                recipient: todo!(),
                 amount: todo!(),
                 start_at: todo!(),
                 end_at: todo!(),
@@ -123,7 +123,6 @@ pub mod fuzz_example3_fuzz_instructions {
         escrow: AccountsStorage<todo!()>,
         escrow_pda_authority: AccountsStorage<todo!()>,
         escrow_token_account: AccountsStorage<todo!()>,
-        i_recipient: AccountsStorage<todo!()>,
         mint: AccountsStorage<todo!()>,
         recipient: AccountsStorage<todo!()>,
         recipient_token_account: AccountsStorage<todo!()>,

--- a/crates/client/tests/test_data/expected_source_codes/expected_fuzz_instructions.rs
+++ b/crates/client/tests/test_data/expected_source_codes/expected_fuzz_instructions.rs
@@ -24,6 +24,7 @@ pub mod fuzz_example3_fuzz_instructions {
     #[derive(Arbitrary, Clone)]
     pub struct InitVestingData {
         pub recipient: AccountId,
+        pub _recipient: AccountId,
         pub amount: u64,
         pub start_at: u64,
         pub end_at: u64,
@@ -58,6 +59,7 @@ pub mod fuzz_example3_fuzz_instructions {
         ) -> Result<Self::IxData, FuzzingError> {
             let data = fuzz_example3::instruction::InitVesting {
                 recipient: todo!(),
+                _recipient: todo!(),
                 amount: todo!(),
                 start_at: todo!(),
                 end_at: todo!(),

--- a/crates/client/tests/test_data/expected_source_codes/expected_fuzz_instructions.rs
+++ b/crates/client/tests/test_data/expected_source_codes/expected_fuzz_instructions.rs
@@ -23,7 +23,7 @@ pub mod fuzz_example3_fuzz_instructions {
     }
     #[derive(Arbitrary, Clone)]
     pub struct InitVestingData {
-        pub recipient: Pubkey,
+        pub i_recipient: AccountId,
         pub amount: u64,
         pub start_at: u64,
         pub end_at: u64,
@@ -57,7 +57,7 @@ pub mod fuzz_example3_fuzz_instructions {
             _fuzz_accounts: &mut FuzzAccounts,
         ) -> Result<Self::IxData, FuzzingError> {
             let data = fuzz_example3::instruction::InitVesting {
-                recipient: todo!(),
+                i_recipient: todo!(),
                 amount: todo!(),
                 start_at: todo!(),
                 end_at: todo!(),
@@ -123,6 +123,7 @@ pub mod fuzz_example3_fuzz_instructions {
         escrow: AccountsStorage<todo!()>,
         escrow_pda_authority: AccountsStorage<todo!()>,
         escrow_token_account: AccountsStorage<todo!()>,
+        i_recipient: AccountsStorage<todo!()>,
         mint: AccountsStorage<todo!()>,
         recipient: AccountsStorage<todo!()>,
         recipient_token_account: AccountsStorage<todo!()>,

--- a/crates/client/tests/test_program/fuzz_example3/Cargo.toml
+++ b/crates/client/tests/test_program/fuzz_example3/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "fuzz_example3"
 version = "0.1.0"

--- a/crates/client/tests/test_program/fuzz_example3/src/lib.rs
+++ b/crates/client/tests/test_program/fuzz_example3/src/lib.rs
@@ -14,13 +14,13 @@ pub mod fuzz_example3 {
 
     pub fn init_vesting(
         ctx: Context<InitVesting>,
-        recipient: Pubkey,
+        i_recipient: Pubkey,
         amount: u64,
         start_at: u64,
         end_at: u64,
         interval: u64,
     ) -> Result<()> {
-        _init_vesting(ctx, recipient, amount, start_at, end_at, interval)
+        _init_vesting(ctx, i_recipient, amount, start_at, end_at, interval)
     }
 
     pub fn withdraw_unlocked(ctx: Context<WithdrawUnlocked>) -> Result<()> {

--- a/crates/client/tests/test_program/fuzz_example3/src/lib.rs
+++ b/crates/client/tests/test_program/fuzz_example3/src/lib.rs
@@ -14,13 +14,13 @@ pub mod fuzz_example3 {
 
     pub fn init_vesting(
         ctx: Context<InitVesting>,
-        i_recipient: Pubkey,
+        recipient: Pubkey,
         amount: u64,
         start_at: u64,
         end_at: u64,
         interval: u64,
     ) -> Result<()> {
-        _init_vesting(ctx, i_recipient, amount, start_at, end_at, interval)
+        _init_vesting(ctx, recipient, amount, start_at, end_at, interval)
     }
 
     pub fn withdraw_unlocked(ctx: Context<WithdrawUnlocked>) -> Result<()> {

--- a/crates/client/tests/test_program/fuzz_example3/src/lib.rs
+++ b/crates/client/tests/test_program/fuzz_example3/src/lib.rs
@@ -15,6 +15,7 @@ pub mod fuzz_example3 {
     pub fn init_vesting(
         ctx: Context<InitVesting>,
         recipient: Pubkey,
+        _recipient: anchor_lang::prelude::Pubkey,
         amount: u64,
         start_at: u64,
         end_at: u64,


### PR DESCRIPTION
If Pubkey is at instruction input, it is converted to AccountID, next the variable name is stored and the FuzzAccounts struct is expanded if an account with the same name does not exist.

However, if a Pubkey is contained within a struct, which itself is an input argument, this approach will not work.

Test_program was updated to test the functionality. 
Added [workspace] into the test_program so the program can be easily expanded.