### PR TITLE
Fix/program client custom types

### DIFF
--- a/crates/client/src/idl.rs
+++ b/crates/client/src/idl.rs
@@ -114,13 +114,11 @@ pub enum Error {
     MissingOrInvalidProgramItems(&'static str),
 }
 
-#[doc = r"Stores module name and it`s visibility"]
 struct ModPub {
     pub mod_name: String,
     pub is_pub: bool,
 }
 
-#[doc = r"Stores important information for obtaining full path for custom types"]
 struct FullPathFinder {
     target_item_name: String,
     current_module: String,
@@ -186,21 +184,17 @@ impl<'ast> syn::visit::Visit<'ast> for FullPathFinder {
     }
 }
 
-#[doc = r"Wrapper through all programs specified within the Solana project"]
 #[derive(Debug)]
 pub struct Idl {
     pub programs: Vec<IdlProgram>,
 }
 
-#[doc = r"Name struct for corresponding program"]
 #[derive(Debug)]
 pub struct IdlName {
     pub snake_case: String,
     pub upper_camel_case: String,
 }
 
-#[doc = r"IdlProgram struct which is generated for each program"]
-#[doc = r"within the project"]
 #[derive(Debug)]
 pub struct IdlProgram {
     pub name: IdlName,
@@ -208,19 +202,12 @@ pub struct IdlProgram {
     pub instruction_account_pairs: Vec<(IdlInstruction, IdlAccountGroup)>,
 }
 
-#[doc = r"IdlInstruction struct contains IdlName of struct"]
-#[doc = r"and corresponding Vector of parameters with their "]
-#[doc = r"types, for custom types such as Struct or Enum,"]
-#[doc = r" full path is obtained"]
 #[derive(Debug)]
 pub struct IdlInstruction {
     pub name: IdlName,
     pub parameters: Vec<(String, String)>,
 }
 
-#[doc = r"IdlAccountGroup struct contains IdlName of struct"]
-#[doc = r"(within Anchor framework perspective - Context), and"]
-#[doc = r"corresponding Accounts with the types"]
 #[derive(Debug)]
 pub struct IdlAccountGroup {
     pub name: IdlName,
@@ -656,7 +643,6 @@ pub async fn parse_to_idl_program(name: String, code: &str) -> Result<IdlProgram
     })
 }
 
-#[doc = r"Recursively looks for '__client_accounts_' modules"]
 fn set_account_modules(account_modules: &mut Vec<syn::ItemMod>, item_module: syn::ItemMod) {
     if item_module
         .ident

--- a/crates/client/src/idl.rs
+++ b/crates/client/src/idl.rs
@@ -96,9 +96,15 @@
 
 use heck::{ToSnakeCase, ToUpperCamelCase};
 use quote::ToTokens;
+use syn::visit::Visit;
 use thiserror::Error;
 
-static ACCOUNT_MOD_PREFIX: &str = "__client_accounts_";
+const ACCOUNT_MOD_PREFIX: &str = "__client_accounts_";
+const MOD_PRIVATE: &str = "__private";
+const MOD_INSTRUCTION: &str = "instruction";
+const MOD_GLOBAL: &str = "__global";
+const ID_IDENT: &str = "ID";
+const ACCOUNTS_IDENT: &str = "__accounts";
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -108,17 +114,93 @@ pub enum Error {
     MissingOrInvalidProgramItems(&'static str),
 }
 
+#[doc = r"Stores module name and it`s visibility"]
+struct ModPub {
+    pub mod_name: String,
+    pub is_pub: bool,
+}
+
+#[doc = r"Stores important information for obtaining full path for custom types"]
+struct FullPathFinder {
+    target_item_name: String,
+    current_module: String,
+    found_path: Option<String>,
+    module_pub: Vec<ModPub>,
+}
+
+fn find_item_path(code: &str, target_item_name: &str) -> Option<String> {
+    let syn_file = syn::parse_file(code).ok()?;
+    let mut finder = FullPathFinder {
+        target_item_name: target_item_name.to_string(),
+        current_module: "".to_string(),
+        found_path: None,
+        module_pub: vec![],
+    };
+    finder.visit_file(&syn_file);
+    finder.found_path
+}
+
+impl<'ast> syn::visit::Visit<'ast> for FullPathFinder {
+    fn visit_item(&mut self, item: &'ast syn::Item) {
+        if let Some(_found_path) = &self.found_path {
+            return;
+        }
+
+        // INFO this will only look for enum or struct
+        match item {
+            syn::Item::Enum(syn::ItemEnum { ident, .. })
+            | syn::Item::Struct(syn::ItemStruct { ident, .. }) => {
+                if *ident == self.target_item_name {
+                    // Found the target item, construct the full path.
+                    self.found_path = Some(format!("{}::{}", self.current_module, ident));
+                    for x in &self.module_pub {
+                        if !x.is_pub {
+                            println!("\nMod: \x1b[91m{}\x1b[0m is private!! \n- modify visibility to \x1b[93mpub\x1b[0m in order to use the custom type inside program_client.", x.mod_name)
+                        }
+                    }
+                    return;
+                }
+            }
+
+            _ => {}
+        }
+
+        syn::visit::visit_item(self, item);
+    }
+
+    fn visit_item_mod(&mut self, module: &'ast syn::ItemMod) {
+        let old_module = self.current_module.clone();
+        self.current_module = format!("{}::{}", self.current_module, module.ident);
+
+        let is_pub = matches!(module.vis, syn::Visibility::Public(_));
+
+        self.module_pub.push(ModPub {
+            mod_name: module.ident.to_string(),
+            is_pub,
+        });
+
+        syn::visit::visit_item_mod(self, module);
+
+        self.module_pub.pop();
+        self.current_module = old_module;
+    }
+}
+
+#[doc = r"Wrapper through all programs specified within the Solana project"]
 #[derive(Debug)]
 pub struct Idl {
     pub programs: Vec<IdlProgram>,
 }
 
+#[doc = r"Name struct for corresponding program"]
 #[derive(Debug)]
 pub struct IdlName {
     pub snake_case: String,
     pub upper_camel_case: String,
 }
 
+#[doc = r"IdlProgram struct which is generated for each program"]
+#[doc = r"within the project"]
 #[derive(Debug)]
 pub struct IdlProgram {
     pub name: IdlName,
@@ -126,12 +208,19 @@ pub struct IdlProgram {
     pub instruction_account_pairs: Vec<(IdlInstruction, IdlAccountGroup)>,
 }
 
+#[doc = r"IdlInstruction struct contains IdlName of struct"]
+#[doc = r"and corresponding Vector of parameters with their "]
+#[doc = r"types, for custom types such as Struct or Enum,"]
+#[doc = r" full path is obtained"]
 #[derive(Debug)]
 pub struct IdlInstruction {
     pub name: IdlName,
     pub parameters: Vec<(String, String)>,
 }
 
+#[doc = r"IdlAccountGroup struct contains IdlName of struct"]
+#[doc = r"(within Anchor framework perspective - Context), and"]
+#[doc = r"corresponding Accounts with the types"]
 #[derive(Debug)]
 pub struct IdlAccountGroup {
     pub name: IdlName,
@@ -146,12 +235,12 @@ pub async fn parse_to_idl_program(name: String, code: &str) -> Result<IdlProgram
 
     for item in syn::parse_file(code)?.items.into_iter() {
         match item {
-            syn::Item::Static(item_static) if item_static.ident == "ID" => {
+            syn::Item::Static(item_static) if item_static.ident == ID_IDENT => {
                 static_program_id = Some(item_static);
             }
             syn::Item::Mod(item_mod) => match item_mod.ident.to_string().as_str() {
-                "__private" => mod_private = Some(item_mod),
-                "instruction" => mod_instruction = Some(item_mod),
+                MOD_PRIVATE => mod_private = Some(item_mod),
+                MOD_INSTRUCTION => mod_instruction = Some(item_mod),
                 _ => set_account_modules(&mut account_mods, item_mod),
             },
             _ => (),
@@ -167,27 +256,19 @@ pub async fn parse_to_idl_program(name: String, code: &str) -> Result<IdlProgram
     ))?;
 
     // ------ get program id ------
-
+    // Obtain Program ID
+    //
     // input example:
+    //
     // ```
+    //
     // pub static ID: anchor_lang::solana_program::pubkey::Pubkey =
-    //     anchor_lang::solana_program::pubkey::Pubkey::new_from_array([216u8, 55u8,
-    //                                                                  200u8, 93u8,
-    //                                                                  189u8, 81u8,
-    //                                                                  94u8, 109u8,
-    //                                                                  14u8, 249u8,
-    //                                                                  244u8, 106u8,
-    //                                                                  68u8, 214u8,
-    //                                                                  222u8, 190u8,
-    //                                                                  9u8, 25u8,
-    //                                                                  199u8, 75u8,
-    //                                                                  79u8, 230u8,
-    //                                                                  94u8, 137u8,
-    //                                                                  51u8, 187u8,
-    //                                                                  193u8, 48u8,
-    //                                                                  87u8, 222u8,
-    //                                                                  175u8,
-    //                                                                  163u8]);
+    // anchor_lang::solana_program::pubkey::Pubkey::new_from_array([
+    //     222u8, 219u8, 96u8, 222u8, 150u8, 129u8, 32u8, 71u8, 184u8, 221u8, 54u8, 221u8, 224u8,
+    //     97u8, 103u8, 133u8, 11u8, 126u8, 234u8, 11u8, 186u8, 25u8, 119u8, 161u8, 48u8, 137u8, 77u8,
+    //     249u8, 144u8, 153u8, 133u8, 92u8,
+    // ]);
+    //
     // ```
 
     let program_id_bytes = {
@@ -210,27 +291,63 @@ pub async fn parse_to_idl_program(name: String, code: &str) -> Result<IdlProgram
     };
 
     // ------ get instruction_item_fns ------
-
+    // Obtain Instructions as whole, parse at next step
+    //
     // input example:
+    //
     // ```
+    //
     // mod __private {
+    //     use super::*;
+    //     #[doc = r" __global mod defines wrapped handlers for global instructions."]
     //     pub mod __global {
     //         use super::*;
     //         #[inline(never)]
-    //         pub fn initialize(program_id: &Pubkey, accounts: &[AccountInfo],
-    //                           ix_data: &[u8]) -> ProgramResult {
-    //             let ix =
-    //                 instruction::Initialize::deserialize(&mut &ix_data[..]).map_err(|_|
-    //                                                                                     anchor_lang::__private::ErrorCode::InstructionDidNotDeserialize)?;
-    //             let instruction::Initialize = ix;
-    //             let mut remaining_accounts: &[AccountInfo] = accounts;
-    //             let mut accounts =
-    //                 Initialize::try_accounts(program_id, &mut remaining_accounts,
-    //                                          ix_data)?;
-    //             turnstile::initialize(Context::new(program_id, &mut accounts,
-    //                                                remaining_accounts))?;
-    //             accounts.exit(program_id)
+    //         pub fn init_vesting(
+    //             __program_id: &Pubkey,
+    //             __accounts: &[AccountInfo],
+    //             __ix_data: &[u8],
+    //         ) -> anchor_lang::Result<()> {
+    //             ::solana_program::log::sol_log("Instruction: InitVesting");
+    //             let ix = instruction::InitVesting::deserialize(&mut &__ix_data[..])
+    //                 .map_err(|_| anchor_lang::error::ErrorCode::InstructionDidNotDeserialize)?;
+    //             let instruction::InitVesting {
+    //                 recipient,
+    //                 amount,
+    //                 start_at,
+    //                 end_at,
+    //                 interval,
+    //                 input_option,
+    //             } = ix;
+    //             let mut __bumps = std::collections::BTreeMap::new();
+    //             let mut __reallocs = std::collections::BTreeSet::new();
+    //             let mut __remaining_accounts: &[AccountInfo] = __accounts;
+    //             let mut __accounts = InitVesting::try_accounts(
+    //                 __program_id,
+    //                 &mut __remaining_accounts,
+    //                 __ix_data,
+    //                 &mut __bumps,
+    //                 &mut __reallocs,
+    //             )?;
+    //             let result = fuzz_example3::init_vesting(
+    //                 anchor_lang::context::Context::new(
+    //                     __program_id,
+    //                     &mut __accounts,
+    //                     __remaining_accounts,
+    //                     __bumps,
+    //                 ),
+    //                 recipient,
+    //                 amount,
+    //                 start_at,
+    //                 end_at,
+    //                 interval,
+    //                 input_option,
+    //             )?;
+    //             __accounts.exit(__program_id)
     //         }
+    //     }
+    // }
+    //
     // ```
 
     let instruction_item_fns = {
@@ -241,7 +358,7 @@ pub async fn parse_to_idl_program(name: String, code: &str) -> Result<IdlProgram
         let item_mod_global = items
             .into_iter()
             .find_map(|item| match item {
-                syn::Item::Mod(item_mod) if item_mod.ident == "__global" => Some(item_mod),
+                syn::Item::Mod(item_mod) if item_mod.ident == MOD_GLOBAL => Some(item_mod),
                 _ => None?,
             })
             .ok_or(Error::MissingOrInvalidProgramItems(
@@ -258,23 +375,64 @@ pub async fn parse_to_idl_program(name: String, code: &str) -> Result<IdlProgram
     };
 
     // ------ get instruction + account group names ------
-
+    // This will obtain:
+    // IdlInstruction
+    //      - name
+    //      - empty parameters vector
+    // IdlAccountGroup (Which is actually Context from Anchor perspective)
+    //      - name
+    //      - empty accounts vector
     // input example:
+    //
     // ```
-    //         pub fn initialize(program_id: &Pubkey, accounts: &[AccountInfo],
-    //                           ix_data: &[u8]) -> ProgramResult {
-    //             let ix =
-    //                 instruction::Initialize::deserialize(&mut &ix_data[..]).map_err(|_|
-    //                                                                                     anchor_lang::__private::ErrorCode::InstructionDidNotDeserialize)?;
-    //             let instruction::Initialize = ix;
-    //             let mut remaining_accounts: &[AccountInfo] = accounts;
-    //             let mut accounts =
-    //                 Initialize::try_accounts(program_id, &mut remaining_accounts,
-    //                                          ix_data)?;
-    //             turnstile::initialize(Context::new(program_id, &mut accounts,
-    //                                                remaining_accounts))?;
-    //             accounts.exit(program_id)
+    //
+    //         pub fn init_vesting(
+    //             __program_id: &Pubkey,
+    //             __accounts: &[AccountInfo],
+    //             __ix_data: &[u8],
+    //         ) -> anchor_lang::Result<()> {
+    //             ::solana_program::log::sol_log("Instruction: InitVesting");
+    //             let ix = instruction::InitVesting::deserialize(&mut &__ix_data[..])
+    //                 .map_err(|_| anchor_lang::error::ErrorCode::InstructionDidNotDeserialize)?;
+    //             let instruction::InitVesting {
+    //                 recipient,
+    //                 amount,
+    //                 start_at,
+    //                 end_at,
+    //                 interval,
+    //                 input_option,
+    //             } = ix;
+    //             let mut __bumps = std::collections::BTreeMap::new();
+    //             let mut __reallocs = std::collections::BTreeSet::new();
+    //             let mut __remaining_accounts: &[AccountInfo] = __accounts;
+    //
+    // *** we are looking for this part ***
+    //
+    //             let mut __accounts = InitVesting::try_accounts(
+    //                 __program_id,
+    //                 &mut __remaining_accounts,
+    //                 __ix_data,
+    //                 &mut __bumps,
+    //                 &mut __reallocs,
+    //             )?;
+    // *************************************
+    //             let result = fuzz_example3::init_vesting(
+    //                 anchor_lang::context::Context::new(
+    //                     __program_id,
+    //                     &mut __accounts,
+    //                     __remaining_accounts,
+    //                     __bumps,
+    //                 ),
+    //                 recipient,
+    //                 amount,
+    //                 start_at,
+    //                 end_at,
+    //                 interval,
+    //                 input_option,
+    //             )?;
+    //             __accounts.exit(__program_id)
     //         }
+    //
     // ```
 
     let mut instruction_account_pairs = Vec::new();
@@ -283,29 +441,29 @@ pub async fn parse_to_idl_program(name: String, code: &str) -> Result<IdlProgram
         .map(|item_fn| {
             // stmt example: `let mut accounts = UpdateState::try_accounts(program_id, &mut remaining_accounts, ix_data)?;`
             let account_group_name = item_fn.block.stmts.into_iter().find_map(|stmt| {
-            let local = if let syn::Stmt::Local(local) = stmt {
-                local
-            } else {
-                None?
-            };
-            if !matches!(&local.pat, syn::Pat::Ident(pat_ident) if pat_ident.ident == "__accounts") {
-                None?
-            }
-            let init_expr = *local.init?.1;
-            let expr_try_expr = match init_expr {
-                syn::Expr::Try(expr_try) => *expr_try.expr,
-                _ => None?
-            };
-            let expr_call_func = match expr_try_expr {
-                syn::Expr::Call(expr_call) => *expr_call.func,
-                _ => None?
-            };
-            let account_group_name = match expr_call_func {
-                syn::Expr::Path(expr_path) => expr_path.path.segments.into_iter().next()?.ident,
-                _ => None?
-            };
-            Some(account_group_name.to_string())
-        })?;
+                let local = if let syn::Stmt::Local(local) = stmt {
+                    local
+                } else {
+                    None?
+                };
+                if !matches!(&local.pat, syn::Pat::Ident(pat_ident) if pat_ident.ident == ACCOUNTS_IDENT) {
+                    None?
+                }
+                let init_expr = *local.init?.1;
+                let expr_try_expr = match init_expr {
+                    syn::Expr::Try(expr_try) => *expr_try.expr,
+                    _ => None?,
+                };
+                let expr_call_func = match expr_try_expr {
+                    syn::Expr::Call(expr_call) => *expr_call.func,
+                    _ => None?,
+                };
+                let account_group_name = match expr_call_func {
+                    syn::Expr::Path(expr_path) => expr_path.path.segments.into_iter().next()?.ident,
+                    _ => None?,
+                };
+                Some(account_group_name.to_string())
+            })?;
 
             let instruction_name = item_fn.sig.ident.to_string();
             let idl_instruction = IdlInstruction {
@@ -336,20 +494,35 @@ pub async fn parse_to_idl_program(name: String, code: &str) -> Result<IdlProgram
         })?;
 
     // ------ get instruction parameters ------
-
+    // This will obtain input parameters for every instruction
+    // For custom types such as Struct or Enum, which can be also at instruction
+    // input, we look for fully qualified path such as:
+    // fuzz_example3::instructions::initialize::CustomInputOption
+    //
     // input example:
+    //
     // ```
+    //
     // pub mod instruction {
     //     use super::*;
-    //     pub mod state {
-    //         use super::*;
+    //     #[doc = r" Instruction."]
+    //     pub struct InitVesting {
+    //         pub recipient: Pubkey,
+    //         pub amount: u64,
+    //         pub start_at: u64,
+    //         pub end_at: u64,
+    //         pub interval: u64,
+    //         pub input_option: CustomInputOption,
     //     }
-    // // **
-    //     pub struct Initialize;
-    // // **
-    //     pub struct Coin {
-    //         pub dummy_arg: String,
-    //     }
+    //      ...
+    //      ...
+    //      ...
+    //      pub struct WithdrawUnlocked;
+    //      ...
+    //      ...
+    //      ...
+    // }
+    //
     // ```
 
     let mut instruction_mod_items = mod_instruction
@@ -386,23 +559,38 @@ pub async fn parse_to_idl_program(name: String, code: &str) -> Result<IdlProgram
             .map(|field| {
                 let parameter_name = field.ident.unwrap().to_string();
                 let parameter_id_type = field.ty.into_token_stream().to_string();
-                (parameter_name, parameter_id_type)
+
+                if let Some(path) = find_item_path(code, &parameter_id_type) {
+                    let tmp_final_path = format!("{name}{path}");
+                    (parameter_name, tmp_final_path)
+                } else {
+                    (parameter_name, parameter_id_type)
+                }
             })
             .collect();
     }
 
     // ------ get accounts ------
-
+    // This will obtain corresponding Context for every Instruction
     // input example:
+    //
     // ```
-    // pub(crate) mod __client_accounts_initialize {
+    //
+    // pub(crate) mod __client_accounts_init_vesting {
     //     use super::*;
     //     use anchor_lang::prelude::borsh;
-    //     pub struct Initialize {
-    //         pub state: anchor_lang::solana_program::pubkey::Pubkey,
-    //         pub user: anchor_lang::solana_program::pubkey::Pubkey,
+    //     #[doc = " Generated client accounts for [`InitVesting`]."]
+    //     pub struct InitVesting {
+    //         pub sender: anchor_lang::solana_program::pubkey::Pubkey,
+    //         pub sender_token_account: anchor_lang::solana_program::pubkey::Pubkey,
+    //         pub escrow: anchor_lang::solana_program::pubkey::Pubkey,
+    //         pub escrow_token_account: anchor_lang::solana_program::pubkey::Pubkey,
+    //         pub mint: anchor_lang::solana_program::pubkey::Pubkey,
+    //         pub token_program: anchor_lang::solana_program::pubkey::Pubkey,
     //         pub system_program: anchor_lang::solana_program::pubkey::Pubkey,
     //     }
+    // }
+    //
     // ```
 
     for account_mod_item in account_mods {
@@ -468,6 +656,7 @@ pub async fn parse_to_idl_program(name: String, code: &str) -> Result<IdlProgram
     })
 }
 
+#[doc = r"Recursively looks for '__client_accounts_' modules"]
 fn set_account_modules(account_modules: &mut Vec<syn::ItemMod>, item_module: syn::ItemMod) {
     if item_module
         .ident

--- a/crates/client/src/idl.rs
+++ b/crates/client/src/idl.rs
@@ -549,6 +549,7 @@ pub async fn parse_to_idl_program(name: String, code: &str) -> Result<IdlProgram
                 let parameter_id_type = field.ty.into_token_stream().to_string();
 
                 if let Some(path) = find_item_path(&parameter_id_type, &syn_file) {
+                    let name = name.to_snake_case();
                     let tmp_final_path = format!("{name}{path}");
                     (parameter_name, tmp_final_path)
                 } else {

--- a/crates/client/tests/test_data/expanded_source_codes/expanded_escrow.rs
+++ b/crates/client/tests/test_data/expanded_source_codes/expanded_escrow.rs
@@ -26,6 +26,229 @@ use anchor_spl::token::{
     TokenAccount, Transfer,
 };
 
+pub mod innerstate {
+    use super::*;
+
+    pub enum EnumInputInner {
+        Variant1,
+        Variant2,
+        Variant3,
+        Variant4,
+        Variant5,
+    }
+    impl borsh::de::BorshDeserialize for EnumInputInner {
+        fn deserialize_reader<R: borsh::maybestd::io::Read>(reader: &mut R)
+            -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
+            let tag =
+                <u8 as
+                            borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
+            <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
+        }
+    }
+    impl borsh::de::EnumExt for EnumInputInner {
+        fn deserialize_variant<R: borsh::maybestd::io::Read>(reader: &mut R,
+            variant_idx: u8)
+            -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
+            let mut return_value =
+                match variant_idx {
+                    0u8 => EnumInputInner::Variant1,
+                    1u8 => EnumInputInner::Variant2,
+                    2u8 => EnumInputInner::Variant3,
+                    3u8 => EnumInputInner::Variant4,
+                    4u8 => EnumInputInner::Variant5,
+                    _ =>
+                        return Err(borsh::maybestd::io::Error::new(borsh::maybestd::io::ErrorKind::InvalidInput,
+
+
+
+
+
+
+
+
+
+
+                                    // Transferring from initializer to taker
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                    {
+                                        let res =
+                                            ::alloc::fmt::format(format_args!("Unexpected variant index: {0:?}",
+                                                    variant_idx));
+                                        res
+                                    })),
+                };
+            Ok(return_value)
+        }
+    }
+    impl borsh::ser::BorshSerialize for EnumInputInner {
+        fn serialize<W: borsh::maybestd::io::Write>(&self, writer: &mut W)
+            -> ::core::result::Result<(), borsh::maybestd::io::Error> {
+            let variant_idx: u8 =
+                match self {
+                    EnumInputInner::Variant1 => 0u8,
+                    EnumInputInner::Variant2 => 1u8,
+                    EnumInputInner::Variant3 => 2u8,
+                    EnumInputInner::Variant4 => 3u8,
+                    EnumInputInner::Variant5 => 4u8,
+                };
+            writer.write_all(&variant_idx.to_le_bytes())?;
+            match self {
+                EnumInputInner::Variant1 => {}
+                EnumInputInner::Variant2 => {}
+                EnumInputInner::Variant3 => {}
+                EnumInputInner::Variant4 => {}
+                EnumInputInner::Variant5 => {}
+            }
+            Ok(())
+        }
+    }
+}
+pub use crate::innerstate::*;
+pub mod state {
+    use anchor_lang::prelude::*;
+    pub enum EnumInput { Variant1, Variant2, Variant3, Variant4, Variant5, }
+    impl borsh::de::BorshDeserialize for EnumInput {
+        fn deserialize_reader<R: borsh::maybestd::io::Read>(reader: &mut R)
+            -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
+            let tag =
+                <u8 as
+                            borsh::de::BorshDeserialize>::deserialize_reader(reader)?;
+            <Self as borsh::de::EnumExt>::deserialize_variant(reader, tag)
+        }
+    }
+    impl borsh::de::EnumExt for EnumInput {
+        fn deserialize_variant<R: borsh::maybestd::io::Read>(reader: &mut R,
+            variant_idx: u8)
+            -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
+            let mut return_value =
+                match variant_idx {
+                    0u8 => EnumInput::Variant1,
+                    1u8 => EnumInput::Variant2,
+                    2u8 => EnumInput::Variant3,
+                    3u8 => EnumInput::Variant4,
+                    4u8 => EnumInput::Variant5,
+                    _ =>
+                        return Err(borsh::maybestd::io::Error::new(borsh::maybestd::io::ErrorKind::InvalidInput,
+                                    {
+                                        let res =
+                                            ::alloc::fmt::format(format_args!("Unexpected variant index: {0:?}",
+                                                    variant_idx));
+                                        res
+                                    })),
+                };
+            Ok(return_value)
+        }
+    }
+    impl borsh::ser::BorshSerialize for EnumInput {
+        fn serialize<W: borsh::maybestd::io::Write>(&self, writer: &mut W)
+            -> ::core::result::Result<(), borsh::maybestd::io::Error> {
+            let variant_idx: u8 =
+                match self {
+                    EnumInput::Variant1 => 0u8,
+                    EnumInput::Variant2 => 1u8,
+                    EnumInput::Variant3 => 2u8,
+                    EnumInput::Variant4 => 3u8,
+                    EnumInput::Variant5 => 4u8,
+                };
+            writer.write_all(&variant_idx.to_le_bytes())?;
+            match self {
+                EnumInput::Variant1 => {}
+                EnumInput::Variant2 => {}
+                EnumInput::Variant3 => {}
+                EnumInput::Variant4 => {}
+                EnumInput::Variant5 => {}
+            }
+            Ok(())
+        }
+    }
+    pub struct StructInput {
+        pub field1: u8,
+        pub field2: String,
+        pub field3: StructInputInner,
+    }
+    impl borsh::de::BorshDeserialize for StructInput where
+        u8: borsh::BorshDeserialize, String: borsh::BorshDeserialize,
+        StructInputInner: borsh::BorshDeserialize {
+        fn deserialize_reader<R: borsh::maybestd::io::Read>(reader: &mut R)
+            -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
+            Ok(Self {
+                    field1: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                    field2: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                    field3: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                })
+        }
+    }
+    impl borsh::ser::BorshSerialize for StructInput where
+        u8: borsh::ser::BorshSerialize, String: borsh::ser::BorshSerialize,
+        StructInputInner: borsh::ser::BorshSerialize {
+        fn serialize<W: borsh::maybestd::io::Write>(&self, writer: &mut W)
+            -> ::core::result::Result<(), borsh::maybestd::io::Error> {
+            borsh::BorshSerialize::serialize(&self.field1, writer)?;
+            borsh::BorshSerialize::serialize(&self.field2, writer)?;
+            borsh::BorshSerialize::serialize(&self.field3, writer)?;
+            Ok(())
+        }
+    }
+    #[automatically_derived]
+    impl ::core::default::Default for StructInput {
+        #[inline]
+        fn default() -> StructInput {
+            StructInput {
+                field1: ::core::default::Default::default(),
+                field2: ::core::default::Default::default(),
+                field3: ::core::default::Default::default(),
+            }
+        }
+    }
+    pub struct StructInputInner {
+        pub field1: Pubkey,
+        pub field2: String,
+    }
+    impl borsh::de::BorshDeserialize for StructInputInner where
+        Pubkey: borsh::BorshDeserialize, String: borsh::BorshDeserialize {
+        fn deserialize_reader<R: borsh::maybestd::io::Read>(reader: &mut R)
+            -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
+            Ok(Self {
+                    field1: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                    field2: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                })
+        }
+    }
+    impl borsh::ser::BorshSerialize for StructInputInner where
+        Pubkey: borsh::ser::BorshSerialize, String: borsh::ser::BorshSerialize
+        {
+        fn serialize<W: borsh::maybestd::io::Write>(&self, writer: &mut W)
+            -> ::core::result::Result<(), borsh::maybestd::io::Error> {
+            borsh::BorshSerialize::serialize(&self.field1, writer)?;
+            borsh::BorshSerialize::serialize(&self.field2, writer)?;
+            Ok(())
+        }
+    }
+    #[automatically_derived]
+    impl ::core::default::Default for StructInputInner {
+        #[inline]
+        fn default() -> StructInputInner {
+            StructInputInner {
+                field1: ::core::default::Default::default(),
+                field2: ::core::default::Default::default(),
+            }
+        }
+    }
+}
+pub use crate::state::*;
 #[doc = r" The static program ID"]
 pub static ID: anchor_lang::solana_program::pubkey::Pubkey =
     anchor_lang::solana_program::pubkey::Pubkey::new_from_array([5u8, 214u8,
@@ -39,30 +262,7 @@ pub fn check_id(id: &anchor_lang::solana_program::pubkey::Pubkey) -> bool {
 }
 #[doc = r" Returns the program ID"]
 pub fn id() -> anchor_lang::solana_program::pubkey::Pubkey { ID }
-
 use self::escrow::*;
-
-
-
-
-
-
-
-// Transferring from initializer to taker
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 /// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
@@ -358,7 +558,7 @@ mod __private {
                                             error_msg: anchor_lang::error::ErrorCode::AccountDiscriminatorMismatch.to_string(),
                                             error_origin: Some(anchor_lang::error::ErrorOrigin::Source(anchor_lang::error::Source {
                                                         filename: "programs/escrow/src/lib.rs",
-                                                        line: 25u32,
+                                                        line: 42u32,
                                                     })),
                                             compared_values: None,
                                         }).with_account_name("IdlAccount"));
@@ -1697,7 +1897,7 @@ mod __private {
                                         error_msg: anchor_lang::error::ErrorCode::RequireEqViolated.to_string(),
                                         error_origin: Some(anchor_lang::error::ErrorOrigin::Source(anchor_lang::error::Source {
                                                     filename: "programs/escrow/src/lib.rs",
-                                                    line: 25u32,
+                                                    line: 42u32,
                                                 })),
                                         compared_values: None,
                                     }).with_values((idl_expansion.len(), idl_data.len())));
@@ -1730,7 +1930,7 @@ mod __private {
                                         error_msg: anchor_lang::error::ErrorCode::RequireGteViolated.to_string(),
                                         error_origin: Some(anchor_lang::error::ErrorOrigin::Source(anchor_lang::error::Source {
                                                     filename: "programs/escrow/src/lib.rs",
-                                                    line: 25u32,
+                                                    line: 42u32,
                                                 })),
                                         compared_values: None,
                                     }).with_values((target.len(), buffer_len)));
@@ -1752,7 +1952,11 @@ mod __private {
                 instruction::InitializeEscrow::deserialize(&mut &__ix_data[..]).map_err(|_|
                             anchor_lang::error::ErrorCode::InstructionDidNotDeserialize)?;
             let instruction::InitializeEscrow {
-                    initializer_amount, taker_amount } = ix;
+                    initializer_amount,
+                    taker_amount,
+                    _enum_variant,
+                    _enum_variant_inner,
+                    _struct_variant_inner } = ix;
             let mut __bumps = std::collections::BTreeMap::new();
             let mut __reallocs = std::collections::BTreeSet::new();
             let mut __remaining_accounts: &[AccountInfo] = __accounts;
@@ -1763,7 +1967,8 @@ mod __private {
             let result =
                 escrow::initialize_escrow(anchor_lang::context::Context::new(__program_id,
                             &mut __accounts, __remaining_accounts, __bumps),
-                        initializer_amount, taker_amount)?;
+                        initializer_amount, taker_amount, _enum_variant,
+                        _enum_variant_inner, _struct_variant_inner)?;
             __accounts.exit(__program_id)
         }
         #[inline(never)]
@@ -1813,7 +2018,9 @@ pub mod escrow {
     use super::*;
     const ESCROW_PDA_SEED: &[u8] = b"escrow";
     pub fn initialize_escrow(ctx: Context<InitializeEscrow>,
-        initializer_amount: u64, taker_amount: u64) -> Result<()> {
+        initializer_amount: u64, taker_amount: u64, _enum_variant: EnumInput,
+        _enum_variant_inner: EnumInputInner,
+        _struct_variant_inner: StructInput) -> Result<()> {
         ctx.accounts.escrow_account.initializer_key =
             *ctx.accounts.initializer.key;
         ctx.accounts.escrow_account.initializer_deposit_token_account =
@@ -1865,24 +2072,41 @@ pub mod instruction {
     pub struct InitializeEscrow {
         pub initializer_amount: u64,
         pub taker_amount: u64,
+        pub _enum_variant: EnumInput,
+        pub _enum_variant_inner: EnumInputInner,
+        pub _struct_variant_inner: StructInput,
     }
     impl borsh::ser::BorshSerialize for InitializeEscrow where
-        u64: borsh::ser::BorshSerialize, u64: borsh::ser::BorshSerialize {
+        u64: borsh::ser::BorshSerialize, u64: borsh::ser::BorshSerialize,
+        EnumInput: borsh::ser::BorshSerialize,
+        EnumInputInner: borsh::ser::BorshSerialize,
+        StructInput: borsh::ser::BorshSerialize {
         fn serialize<W: borsh::maybestd::io::Write>(&self, writer: &mut W)
             -> ::core::result::Result<(), borsh::maybestd::io::Error> {
             borsh::BorshSerialize::serialize(&self.initializer_amount,
                     writer)?;
             borsh::BorshSerialize::serialize(&self.taker_amount, writer)?;
+            borsh::BorshSerialize::serialize(&self._enum_variant, writer)?;
+            borsh::BorshSerialize::serialize(&self._enum_variant_inner,
+                    writer)?;
+            borsh::BorshSerialize::serialize(&self._struct_variant_inner,
+                    writer)?;
             Ok(())
         }
     }
     impl borsh::de::BorshDeserialize for InitializeEscrow where
-        u64: borsh::BorshDeserialize, u64: borsh::BorshDeserialize {
+        u64: borsh::BorshDeserialize, u64: borsh::BorshDeserialize,
+        EnumInput: borsh::BorshDeserialize,
+        EnumInputInner: borsh::BorshDeserialize,
+        StructInput: borsh::BorshDeserialize {
         fn deserialize_reader<R: borsh::maybestd::io::Read>(reader: &mut R)
             -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
             Ok(Self {
                     initializer_amount: borsh::BorshDeserialize::deserialize_reader(reader)?,
                     taker_amount: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                    _enum_variant: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                    _enum_variant_inner: borsh::BorshDeserialize::deserialize_reader(reader)?,
+                    _struct_variant_inner: borsh::BorshDeserialize::deserialize_reader(reader)?,
                 })
         }
     }
@@ -1940,9 +2164,9 @@ pub mod instruction {
 #[doc = r" mirroring the structs deriving `Accounts`, where each field is"]
 #[doc = r" a `Pubkey`. This is useful for specifying accounts for a client."]
 pub mod accounts {
+    pub use crate::__client_accounts_initialize_escrow::*;
     pub use crate::__client_accounts_exchange::*;
     pub use crate::__client_accounts_cancel_escrow::*;
-    pub use crate::__client_accounts_initialize_escrow::*;
 }
 #[instruction(initializer_amount : u64)]
 pub struct InitializeEscrow<'info> {
@@ -2061,7 +2285,7 @@ impl<'info> anchor_lang::Accounts<'info> for InitializeEscrow<'info> where
                                                                error_msg: anchor_lang::error::ErrorCode::TryingToInitPayerAsProgramAccount.to_string(),
                                                                error_origin: Some(anchor_lang::error::ErrorOrigin::Source(anchor_lang::error::Source {
                                                                            filename: "programs/escrow/src/lib.rs",
-                                                                           line: 103u32,
+                                                                           line: 123u32,
                                                                        })),
                                                                compared_values: None,
                                                            }).with_pubkeys((initializer.key(), escrow_account.key())));
@@ -3002,7 +3226,7 @@ impl anchor_lang::AccountDeserialize for EscrowAccount {
                                     error_msg: anchor_lang::error::ErrorCode::AccountDiscriminatorMismatch.to_string(),
                                     error_origin: Some(anchor_lang::error::ErrorOrigin::Source(anchor_lang::error::Source {
                                                 filename: "programs/escrow/src/lib.rs",
-                                                line: 169u32,
+                                                line: 189u32,
                                             })),
                                     compared_values: None,
                                 }).with_account_name("EscrowAccount"));

--- a/crates/client/tests/test_data/expected_source_codes/expected_program_client_code.rs
+++ b/crates/client/tests/test_data/expected_source_codes/expected_program_client_code.rs
@@ -10,6 +10,9 @@ pub mod escrow_instruction {
         client: &Client,
         i_initializer_amount: u64,
         i_taker_amount: u64,
+        i__enum_variant: escrow::state::EnumInput,
+        i__enum_variant_inner: escrow::innerstate::EnumInputInner,
+        i__struct_variant_inner: escrow::state::StructInput,
         a_initializer: Pubkey,
         a_initializer_deposit_token_account: Pubkey,
         a_initializer_receive_token_account: Pubkey,
@@ -24,6 +27,9 @@ pub mod escrow_instruction {
                 escrow::instruction::InitializeEscrow {
                     initializer_amount: i_initializer_amount,
                     taker_amount: i_taker_amount,
+                    _enum_variant: i__enum_variant,
+                    _enum_variant_inner: i__enum_variant_inner,
+                    _struct_variant_inner: i__struct_variant_inner,
                 },
                 escrow::accounts::InitializeEscrow {
                     initializer: a_initializer,
@@ -40,6 +46,9 @@ pub mod escrow_instruction {
     pub fn initialize_escrow_ix(
         i_initializer_amount: u64,
         i_taker_amount: u64,
+        i__enum_variant: escrow::state::EnumInput,
+        i__enum_variant_inner: escrow::innerstate::EnumInputInner,
+        i__struct_variant_inner: escrow::state::StructInput,
         a_initializer: Pubkey,
         a_initializer_deposit_token_account: Pubkey,
         a_initializer_receive_token_account: Pubkey,
@@ -52,6 +61,9 @@ pub mod escrow_instruction {
             data: escrow::instruction::InitializeEscrow {
                 initializer_amount: i_initializer_amount,
                 taker_amount: i_taker_amount,
+                _enum_variant: i__enum_variant,
+                _enum_variant_inner: i__enum_variant_inner,
+                _struct_variant_inner: i__struct_variant_inner,
             }
             .data(),
             accounts: escrow::accounts::InitializeEscrow {

--- a/crates/client/tests/test_program_client.rs
+++ b/crates/client/tests/test_program_client.rs
@@ -17,7 +17,7 @@ pub async fn generate_program_client() {
     // after you've called `makers trdelnik test`.
     let expected_client_code = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
-        "/tests/test_data/expected_source_codes/expected_client_code.rs"
+        "/tests/test_data/expected_source_codes/expected_program_client_code.rs"
     ));
 
     let program_idl =


### PR DESCRIPTION
update parse_to_idl_program so that it can obtain the full path for custom types. The implemented function will warn the user if the path is private and cannot be imported.

This is out of scope, but I found it useful to update the examples.

Added some custom types into the cargo test expected/expanded code so that the functionality can be tested.