### PR TITLE
🧑‍💻 move build command to the start of initialization process

### DIFF
--- a/crates/client/src/test_generator.rs
+++ b/crates/client/src/test_generator.rs
@@ -98,6 +98,8 @@ impl TestGenerator {
         };
         let root_path = root.to_str().unwrap().to_string();
         let commander = Commander::with_root(root_path);
+        commander.build_programs().await?;
+
         commander.create_program_client_crate().await?;
         self.generate_test_files(&root).await?;
         self.update_workspace(&root, "trdelnik-tests/poc_tests")
@@ -117,10 +119,10 @@ impl TestGenerator {
             Ok(root) => root,
             Err(_) => throw!(Error::BadWorkspace),
         };
-        let new_fuzz_test_dir = self.generate_fuzz_test_files(&root).await?;
-
         let root_path = root.to_str().unwrap().to_string();
         let commander = Commander::with_root(root_path);
+        commander.build_programs().await?;
+        let new_fuzz_test_dir = self.generate_fuzz_test_files(&root).await?;
         self.build_program_client(&commander, new_fuzz_test_dir)
             .await?;
         self.update_gitignore(
@@ -132,7 +134,6 @@ impl TestGenerator {
     /// Builds and generates programs for `program_client` module
     #[throws]
     async fn build_program_client(&self, commander: &Commander, new_fuzz_test_dir: PathBuf) {
-        commander.build_programs().await?;
         commander.generate_program_client_deps().await?;
         commander
             .generate_program_client_lib_rs(Some(new_fuzz_test_dir))


### PR DESCRIPTION
I suggest moving the "cargo build-bpf" command to the start of the initialization process for trdelnik tests. This is not a critical hotfix, considering other major pull requests are already open; I view this as a minor improvement.

Currently, during initialization, "cargo build-bpf" is executed as one of the last commands. If the build command fails, the project folder will already contain generated files and folders, which I consider to be undesirable behavior from the user's perspective.