### PR TITLE
🧑‍💻 UX for Init command + remove unnecessary code

### DIFF
--- a/crates/cli/src/command/init.rs
+++ b/crates/cli/src/command/init.rs
@@ -1,9 +1,29 @@
-use anyhow::Error;
+use anyhow::{bail, Error};
+
 use fehler::throws;
 use trdelnik_client::TestGenerator;
 
+use crate::{_check_if_present, _discover};
+const CARGO_TOML: &str = "Cargo.toml";
+const TRDELNIK_TOML: &str = "Trdelnik.toml";
+
 #[throws]
 pub async fn init(skip_fuzzer: bool) {
-    let generator = TestGenerator::new();
-    generator.generate(skip_fuzzer).await?;
+    // find parent directory with Cargo.toml
+    let root = _discover(CARGO_TOML)?;
+    if let Some(r) = root {
+        // check if the Trdelnik.toml is already present in the root directory
+        let present = _check_if_present(&r, TRDELNIK_TOML)?;
+        match present {
+            true => {
+                bail!("It seems that Trdelnik is already initialized because the Trdelnik.toml file was found in the current or parent directory!");
+            }
+            false => {
+                let generator = TestGenerator::new_with_root(&r);
+                generator.generate(skip_fuzzer).await?;
+            }
+        }
+    } else {
+        bail!("It does not seem that Solana Program is initialized because the Cargo.toml file was not found in any parent directory!");
+    };
 }

--- a/crates/client/src/fuzzer/fuzzer_generator.rs
+++ b/crates/client/src/fuzzer/fuzzer_generator.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::idl::Idl;
 use quote::{format_ident, ToTokens};
-use syn::{parse_quote, parse_str};
+use syn::{parse_quote, parse_str, Ident};
 
 /// Generates `fuzz_instructions.rs` from [Idl] created from Anchor programs.
 pub fn generate_source_code(idl: &Idl) -> String {
@@ -175,12 +175,13 @@ pub fn generate_source_code(idl: &Idl) -> String {
 
             let fuzz_accounts = idl_program.instruction_account_pairs.iter().fold(
                 HashMap::new(),
-                |mut fuzz_accounts, (_idl_instruction, idl_account_group)| {
+                |mut fuzz_accounts: HashMap<Ident, String>,
+                 (_idl_instruction, idl_account_group)| {
                     idl_account_group.accounts.iter().fold(
                         &mut fuzz_accounts,
                         |fuzz_accounts, (name, _ty)| {
                             let name = format_ident!("{name}");
-                            fuzz_accounts.entry(name).or_insert_with(|| "".to_string());
+                            fuzz_accounts.entry(name).or_default();
                             fuzz_accounts
                         },
                     );

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.71.0"
+channel = "1.74.0"


### PR DESCRIPTION
Currently, it is possible to call trdelnik init while trdelnik is already initialized within the project directory. This PR checks if int the root directory Trdelnik.toml already exists, if so initialization is halted.

Also, this PR removes unnecessary root discovery -> TestGenerator is initialized with the already discovered root