### PR TITLE
Debug-mode detailed output

### DIFF
--- a/crates/client/derive/display_ix/src/lib.rs
+++ b/crates/client/derive/display_ix/src/lib.rs
@@ -12,8 +12,24 @@ pub fn display_ix(input: TokenStream) -> TokenStream {
             let display_match_arms = enum_data.variants.iter().map(|variant| {
                 let variant_name = &variant.ident;
 
-                quote! {
-                    #enum_name::#variant_name (_) => write!(f, stringify!(#variant_name)),
+                match &variant.fields {
+                    syn::Fields::Unnamed(fields) => {
+                        if fields.unnamed.len() == 1 {
+                            quote! {
+                                #enum_name::#variant_name(ref content) => {
+                                    write!(f, stringify!(#variant_name))?;
+                                    write!(f, "({:#?})", content)
+                                },
+                            }
+                        } else {
+                            quote! {
+                                #enum_name::#variant_name (_) => write!(f, stringify!(#variant_name)),
+                            }
+                        }
+                    },
+                    _ => quote! {
+                        #enum_name::#variant_name => write!(f, stringify!(#variant_name)),
+                    },
                 }
             });
 

--- a/crates/client/derive/display_ix/src/lib.rs
+++ b/crates/client/derive/display_ix/src/lib.rs
@@ -9,6 +9,12 @@ pub fn display_ix(input: TokenStream) -> TokenStream {
 
     let display_impl = match &input.data {
         Data::Enum(enum_data) => {
+            let to_context_string_match_arms = enum_data.variants.iter().map(|variant| {
+                let variant_name = &variant.ident;
+                quote! {
+                    #enum_name::#variant_name (_) => String::from(stringify!(#variant_name)),
+                }
+            });
             let display_match_arms = enum_data.variants.iter().map(|variant| {
                 let variant_name = &variant.ident;
 
@@ -38,6 +44,13 @@ pub fn display_ix(input: TokenStream) -> TokenStream {
                     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                         match self {
                             #(#display_match_arms)*
+                        }
+                    }
+                }
+                impl #enum_name {
+                    fn to_context_string(&self)->String{
+                        match self {
+                            #(#to_context_string_match_arms)*
                         }
                     }
                 }

--- a/crates/client/derive/fuzz_test_executor/src/lib.rs
+++ b/crates/client/derive/fuzz_test_executor/src/lib.rs
@@ -51,10 +51,8 @@ pub fn fuzz_test_executor(input: TokenStream) -> TokenStream {
 
                     if let Err(e) = ix.check(acc_before, acc_after, data).map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string()))) {
                         eprintln!(
-                            "Custom check after the {} instruction did not pass with the error message: {}",
-                            self.to_context_string(), e
-                        );
-                        eprintln!("Instruction data submitted to the instruction were:"); // TODO data does not implement Debug trait -> derive Debug trait on InitializeIx and automaticaly implement conversion from Initialize to InitializeIx
+                            "CRASH DETECTED! Custom check after the {} instruction did not pass!",
+                            self.to_context_string());
                         panic!("{}", e)
                     }
 

--- a/crates/client/derive/fuzz_test_executor/src/lib.rs
+++ b/crates/client/derive/fuzz_test_executor/src/lib.rs
@@ -15,7 +15,7 @@ pub fn fuzz_test_executor(input: TokenStream) -> TokenStream {
                     #enum_name::#variant_name (ix) => {
                     let (mut signers, metas) =
                         if let Ok(acc) = ix.get_accounts(client, &mut accounts.borrow_mut())
-                        .map_err(|e| e.with_origin(Origin::Instruction(self.to_string()))) {
+                        .map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string()))) {
                             acc
                         } else {
                             return Ok(());
@@ -25,7 +25,7 @@ pub fn fuzz_test_executor(input: TokenStream) -> TokenStream {
                     snaphot.capture_before(client).unwrap();
                     let data =
                         if let Ok(data) = ix.get_data(client, &mut accounts.borrow_mut())
-                        .map_err(|e| e.with_origin(Origin::Instruction(self.to_string()))) {
+                        .map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string()))) {
                             data
                         } else {
                             return Ok(());
@@ -42,17 +42,17 @@ pub fn fuzz_test_executor(input: TokenStream) -> TokenStream {
                     transaction.sign(&sig, client.get_last_blockhash());
 
                     let res = client.process_transaction(transaction)
-                    .map_err(|e| e.with_origin(Origin::Instruction(self.to_string())));
+                    .map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string())));
 
                     // this can return FuzzClientErrorWithOrigin
                     snaphot.capture_after(client).unwrap();
                     let (acc_before, acc_after) = snaphot.get_snapshot()
-                        .map_err(|e| e.with_origin(Origin::Instruction(self.to_string()))).unwrap(); // we want to panic if we cannot unwrap to cause a crash
+                        .map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string()))).unwrap(); // we want to panic if we cannot unwrap to cause a crash
 
-                    if let Err(e) = ix.check(acc_before, acc_after, data).map_err(|e| e.with_origin(Origin::Instruction(self.to_string()))) {
+                    if let Err(e) = ix.check(acc_before, acc_after, data).map_err(|e| e.with_origin(Origin::Instruction(self.to_context_string()))) {
                         eprintln!(
                             "Custom check after the {} instruction did not pass with the error message: {}",
-                            self, e
+                            self.to_context_string(), e
                         );
                         eprintln!("Instruction data submitted to the instruction were:"); // TODO data does not implement Debug trait -> derive Debug trait on InitializeIx and automaticaly implement conversion from Initialize to InitializeIx
                         panic!("{}", e)

--- a/crates/client/src/fuzzer/data_builder.rs
+++ b/crates/client/src/fuzzer/data_builder.rs
@@ -72,6 +72,7 @@ where
             for ix in self.iter() {
                 eprintln!("{}", ix);
             }
+            eprintln!("------ End of Instructions sequence ------ ");
         }
 
         for fuzz_ix in &mut self.iter() {
@@ -220,7 +221,7 @@ macro_rules! fuzz_trd {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```rust,ignore
 /// use trdelnik_client::fuzzing::show_account;
 ///
 /// #[derive(Debug)]
@@ -237,7 +238,7 @@ macro_rules! fuzz_trd {
 ///     pre_ix: Self::IxSnapshot,
 ///     post_ix: Self::IxSnapshot,
 ///     ix_data: Self::IxData,
-/// ) -> Result<(), &'static str> {} {
+/// ) -> Result<(), FuzzingError> {
 ///     if let Some(escrow) = pre_ix.escrow{
 ///         show_account!(escrow);
 ///     }

--- a/crates/client/src/fuzzer/data_builder.rs
+++ b/crates/client/src/fuzzer/data_builder.rs
@@ -66,7 +66,7 @@ where
         //         fuzz_target=info",
         // );
 
-        // #[cfg(fuzzing_debug)]
+        #[cfg(fuzzing_debug)]
         {
             eprintln!("Instructions sequence:");
             for ix in self.iter() {
@@ -75,7 +75,7 @@ where
         }
 
         for fuzz_ix in &mut self.iter() {
-            // #[cfg(fuzzing_debug)]
+            #[cfg(fuzzing_debug)]
             eprintln!("Currently processing: {}", fuzz_ix);
 
             fuzz_ix.run_fuzzer(program_id, &self.accounts, client)?;
@@ -210,6 +210,49 @@ macro_rules! fuzz_trd {
             };
             $body
         });
+    };
+}
+/// Prints the details of a given account in a pretty-printed format.
+///
+/// This macro takes a single argument, which is an expression referring to the account
+/// you want to print. The account data structure must implement or derive the [`Debug`]
+/// trait for this macro to work, as it relies on `std::fmt::Debug` for formatting.
+///
+/// # Examples
+///
+/// ```rust
+/// use trdelnik_client::fuzzing::show_account;
+///
+/// #[derive(Debug)]
+/// #[account]
+/// struct Escrow {
+///     recipeint: Pubkey,
+///     id: u32,
+///     balance: f64,
+///     name: String,
+/// }
+///
+/// fn check(
+///     &self,
+///     pre_ix: Self::IxSnapshot,
+///     post_ix: Self::IxSnapshot,
+///     ix_data: Self::IxData,
+/// ) -> Result<(), &'static str> {} {
+///     if let Some(escrow) = pre_ix.escrow{
+///         show_account!(escrow);
+///     }
+/// }
+/// ```
+///
+/// # Requirements
+///
+/// The `account` passed to `show_account!` must implement or derive the [`Debug`] trait.
+/// Attempting to use this macro with a type that does not meet this requirement will
+/// result in a compilation error.
+#[macro_export]
+macro_rules! show_account {
+    ($account:expr) => {
+        eprintln!("{:#?}", $account);
     };
 }
 

--- a/crates/client/src/fuzzer/fuzzer_generator.rs
+++ b/crates/client/src/fuzzer/fuzzer_generator.rs
@@ -79,7 +79,7 @@ pub fn generate_source_code(idl: &Idl) -> String {
                             .collect::<Vec<_>>();
 
                         let ix_enum_variant: syn::ItemStruct = parse_quote! {
-                            #[derive(Arbitrary, Clone)]
+                            #[derive(Arbitrary, Clone, Debug)]
                             pub struct #instruction_name {
                                  pub accounts: #instruction_accounts_name,
                                  pub data: #instruction_data_name
@@ -88,14 +88,14 @@ pub fn generate_source_code(idl: &Idl) -> String {
                         };
 
                         let ix_accounts: syn::ItemStruct = parse_quote! {
-                            #[derive(Arbitrary, Clone)]
+                            #[derive(Arbitrary, Clone, Debug)]
                             pub struct #instruction_accounts_name {
                                  #(pub #accounts),*
                             }
 
                         };
                         let ix_data: syn::ItemStruct = parse_quote! {
-                            #[derive(Arbitrary, Clone)]
+                            #[derive(Arbitrary, Clone, Debug)]
                             pub struct #instruction_data_name {
                                  #(pub #parameters),*
                             }

--- a/crates/client/src/fuzzer/fuzzer_generator.rs
+++ b/crates/client/src/fuzzer/fuzzer_generator.rs
@@ -208,7 +208,7 @@ pub fn generate_source_code(idl: &Idl) -> String {
                     use trdelnik_client::fuzzing::*;
                     use crate::accounts_snapshots::*;
 
-                    #[derive(Arbitrary, Clone, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
+                    #[derive(Arbitrary, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
                     pub enum FuzzInstruction {
                         #(#instructions),*
                     }

--- a/crates/client/src/fuzzer/fuzzer_generator.rs
+++ b/crates/client/src/fuzzer/fuzzer_generator.rs
@@ -79,7 +79,7 @@ pub fn generate_source_code(idl: &Idl) -> String {
                             .collect::<Vec<_>>();
 
                         let ix_enum_variant: syn::ItemStruct = parse_quote! {
-                            #[derive(Arbitrary, Clone, Debug)]
+                            #[derive(Arbitrary, Debug)]
                             pub struct #instruction_name {
                                  pub accounts: #instruction_accounts_name,
                                  pub data: #instruction_data_name
@@ -88,14 +88,14 @@ pub fn generate_source_code(idl: &Idl) -> String {
                         };
 
                         let ix_accounts: syn::ItemStruct = parse_quote! {
-                            #[derive(Arbitrary, Clone, Debug)]
+                            #[derive(Arbitrary, Debug)]
                             pub struct #instruction_accounts_name {
                                  #(pub #accounts),*
                             }
 
                         };
                         let ix_data: syn::ItemStruct = parse_quote! {
-                            #[derive(Arbitrary, Clone, Debug)]
+                            #[derive(Arbitrary, Debug)]
                             pub struct #instruction_data_name {
                                  #(pub #parameters),*
                             }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -23,8 +23,8 @@ pub mod fuzzing {
     pub use super::{
         anchor_lang, anchor_lang::system_program::ID as SYSTEM_PROGRAM_ID,
         anchor_lang::InstructionData, anchor_lang::ToAccountInfo, anchor_lang::ToAccountMetas,
-        fuzz_trd, solana_sdk::account::Account, solana_sdk::transaction::Transaction, Instruction,
-        Keypair, Pubkey, Signer, TempClone,
+        fuzz_trd, show_account, solana_sdk::account::Account, solana_sdk::transaction::Transaction,
+        Instruction, Keypair, Pubkey, Signer, TempClone,
     };
     pub use anchor_client::anchor_lang::solana_program::account_info::AccountInfo;
     pub use anchor_client::anchor_lang::solana_program::hash::Hash;

--- a/crates/client/tests/test_data/expected_source_codes/expected_fuzz_instructions.rs
+++ b/crates/client/tests/test_data/expected_source_codes/expected_fuzz_instructions.rs
@@ -1,17 +1,17 @@
 pub mod fuzz_example3_fuzz_instructions {
     use crate::accounts_snapshots::*;
     use trdelnik_client::fuzzing::*;
-    #[derive(Arbitrary, Clone, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
+    #[derive(Arbitrary, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
     pub enum FuzzInstruction {
         InitVesting(InitVesting),
         WithdrawUnlocked(WithdrawUnlocked),
     }
-    #[derive(Arbitrary, Clone, Debug)]
+    #[derive(Arbitrary, Debug)]
     pub struct InitVesting {
         pub accounts: InitVestingAccounts,
         pub data: InitVestingData,
     }
-    #[derive(Arbitrary, Clone, Debug)]
+    #[derive(Arbitrary, Debug)]
     pub struct InitVestingAccounts {
         pub sender: AccountId,
         pub sender_token_account: AccountId,
@@ -21,7 +21,7 @@ pub mod fuzz_example3_fuzz_instructions {
         pub token_program: AccountId,
         pub system_program: AccountId,
     }
-    #[derive(Arbitrary, Clone, Debug)]
+    #[derive(Arbitrary, Debug)]
     pub struct InitVestingData {
         pub recipient: AccountId,
         pub _recipient: AccountId,
@@ -30,12 +30,12 @@ pub mod fuzz_example3_fuzz_instructions {
         pub end_at: u64,
         pub interval: u64,
     }
-    #[derive(Arbitrary, Clone, Debug)]
+    #[derive(Arbitrary, Debug)]
     pub struct WithdrawUnlocked {
         pub accounts: WithdrawUnlockedAccounts,
         pub data: WithdrawUnlockedData,
     }
-    #[derive(Arbitrary, Clone, Debug)]
+    #[derive(Arbitrary, Debug)]
     pub struct WithdrawUnlockedAccounts {
         pub recipient: AccountId,
         pub recipient_token_account: AccountId,
@@ -46,7 +46,7 @@ pub mod fuzz_example3_fuzz_instructions {
         pub token_program: AccountId,
         pub system_program: AccountId,
     }
-    #[derive(Arbitrary, Clone, Debug)]
+    #[derive(Arbitrary, Debug)]
     pub struct WithdrawUnlockedData {}
     impl<'info> IxOps<'info> for InitVesting {
         type IxData = fuzz_example3::instruction::InitVesting;

--- a/crates/client/tests/test_data/expected_source_codes/expected_fuzz_instructions.rs
+++ b/crates/client/tests/test_data/expected_source_codes/expected_fuzz_instructions.rs
@@ -6,12 +6,12 @@ pub mod fuzz_example3_fuzz_instructions {
         InitVesting(InitVesting),
         WithdrawUnlocked(WithdrawUnlocked),
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Clone, Debug)]
     pub struct InitVesting {
         pub accounts: InitVestingAccounts,
         pub data: InitVestingData,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Clone, Debug)]
     pub struct InitVestingAccounts {
         pub sender: AccountId,
         pub sender_token_account: AccountId,
@@ -21,7 +21,7 @@ pub mod fuzz_example3_fuzz_instructions {
         pub token_program: AccountId,
         pub system_program: AccountId,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Clone, Debug)]
     pub struct InitVestingData {
         pub recipient: AccountId,
         pub _recipient: AccountId,
@@ -30,12 +30,12 @@ pub mod fuzz_example3_fuzz_instructions {
         pub end_at: u64,
         pub interval: u64,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Clone, Debug)]
     pub struct WithdrawUnlocked {
         pub accounts: WithdrawUnlockedAccounts,
         pub data: WithdrawUnlockedData,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Clone, Debug)]
     pub struct WithdrawUnlockedAccounts {
         pub recipient: AccountId,
         pub recipient_token_account: AccountId,
@@ -46,7 +46,7 @@ pub mod fuzz_example3_fuzz_instructions {
         pub token_program: AccountId,
         pub system_program: AccountId,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Clone, Debug)]
     pub struct WithdrawUnlockedData {}
     impl<'info> IxOps<'info> for InitVesting {
         type IxData = fuzz_example3::instruction::InitVesting;

--- a/crates/client/tests/test_data/fuzzer_macros/fuzz_display_ix.expanded.rs
+++ b/crates/client/tests/test_data/fuzzer_macros/fuzz_display_ix.expanded.rs
@@ -6,10 +6,22 @@ pub enum FuzzInstruction {
 impl std::fmt::Display for FuzzInstruction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FuzzInstruction::InitVesting(_) => f.write_fmt(format_args!("InitVesting")),
-            FuzzInstruction::WithdrawUnlocked(_) => {
-                f.write_fmt(format_args!("WithdrawUnlocked"))
+            FuzzInstruction::InitVesting(ref content) => {
+                f.write_fmt(format_args!("InitVesting"))?;
+                f.write_fmt(format_args!("({0:#?})", content))
             }
+            FuzzInstruction::WithdrawUnlocked(ref content) => {
+                f.write_fmt(format_args!("WithdrawUnlocked"))?;
+                f.write_fmt(format_args!("({0:#?})", content))
+            }
+        }
+    }
+}
+impl FuzzInstruction {
+    fn to_context_string(&self) -> String {
+        match self {
+            FuzzInstruction::InitVesting(_) => String::from("InitVesting"),
+            FuzzInstruction::WithdrawUnlocked(_) => String::from("WithdrawUnlocked"),
         }
     }
 }

--- a/crates/client/tests/test_data/fuzzer_macros/fuzz_fuzz_test_executor.expanded.rs
+++ b/crates/client/tests/test_data/fuzzer_macros/fuzz_fuzz_test_executor.expanded.rs
@@ -70,15 +70,8 @@ impl FuzzTestExecutor<FuzzAccounts> for FuzzInstruction {
                     {
                         ::std::io::_eprint(
                             format_args!(
-                                "Custom check after the {0} instruction did not pass with the error message: {1}\n",
-                                self.to_context_string(), e,
-                            ),
-                        );
-                    };
-                    {
-                        ::std::io::_eprint(
-                            format_args!(
-                                "Instruction data submitted to the instruction were:\n",
+                                "CRASH DETECTED! Custom check after the {0} instruction did not pass!\n",
+                                self.to_context_string(),
                             ),
                         );
                     };
@@ -149,15 +142,8 @@ impl FuzzTestExecutor<FuzzAccounts> for FuzzInstruction {
                     {
                         ::std::io::_eprint(
                             format_args!(
-                                "Custom check after the {0} instruction did not pass with the error message: {1}\n",
-                                self.to_context_string(), e,
-                            ),
-                        );
-                    };
-                    {
-                        ::std::io::_eprint(
-                            format_args!(
-                                "Instruction data submitted to the instruction were:\n",
+                                "CRASH DETECTED! Custom check after the {0} instruction did not pass!\n",
+                                self.to_context_string(),
                             ),
                         );
                     };

--- a/crates/client/tests/test_data/fuzzer_macros/fuzz_fuzz_test_executor.expanded.rs
+++ b/crates/client/tests/test_data/fuzzer_macros/fuzz_fuzz_test_executor.expanded.rs
@@ -16,7 +16,7 @@ impl FuzzTestExecutor<FuzzAccounts> for FuzzInstruction {
                     = ix
                         .get_accounts(client, &mut accounts.borrow_mut())
                         .map_err(|e| {
-                            e.with_origin(Origin::Instruction(self.to_string()))
+                            e.with_origin(Origin::Instruction(self.to_context_string()))
                         })
                 {
                     acc
@@ -29,7 +29,7 @@ impl FuzzTestExecutor<FuzzAccounts> for FuzzInstruction {
                     = ix
                         .get_data(client, &mut accounts.borrow_mut())
                         .map_err(|e| {
-                            e.with_origin(Origin::Instruction(self.to_string()))
+                            e.with_origin(Origin::Instruction(self.to_context_string()))
                         })
                 {
                     data
@@ -50,24 +50,28 @@ impl FuzzTestExecutor<FuzzAccounts> for FuzzInstruction {
                 transaction.sign(&sig, client.get_last_blockhash());
                 let res = client
                     .process_transaction(transaction)
-                    .map_err(|e| e.with_origin(Origin::Instruction(self.to_string())));
+                    .map_err(|e| {
+                        e.with_origin(Origin::Instruction(self.to_context_string()))
+                    });
                 snaphot.capture_after(client).unwrap();
                 let (acc_before, acc_after) = snaphot
                     .get_snapshot()
-                    .map_err(|e| e.with_origin(Origin::Instruction(self.to_string())))
+                    .map_err(|e| {
+                        e.with_origin(Origin::Instruction(self.to_context_string()))
+                    })
                     .unwrap();
                 if let Err(e)
                     = ix
                         .check(acc_before, acc_after, data)
                         .map_err(|e| {
-                            e.with_origin(Origin::Instruction(self.to_string()))
+                            e.with_origin(Origin::Instruction(self.to_context_string()))
                         })
                 {
                     {
                         ::std::io::_eprint(
                             format_args!(
                                 "Custom check after the {0} instruction did not pass with the error message: {1}\n",
-                                self, e,
+                                self.to_context_string(), e,
                             ),
                         );
                     };
@@ -91,7 +95,7 @@ impl FuzzTestExecutor<FuzzAccounts> for FuzzInstruction {
                     = ix
                         .get_accounts(client, &mut accounts.borrow_mut())
                         .map_err(|e| {
-                            e.with_origin(Origin::Instruction(self.to_string()))
+                            e.with_origin(Origin::Instruction(self.to_context_string()))
                         })
                 {
                     acc
@@ -104,7 +108,7 @@ impl FuzzTestExecutor<FuzzAccounts> for FuzzInstruction {
                     = ix
                         .get_data(client, &mut accounts.borrow_mut())
                         .map_err(|e| {
-                            e.with_origin(Origin::Instruction(self.to_string()))
+                            e.with_origin(Origin::Instruction(self.to_context_string()))
                         })
                 {
                     data
@@ -125,24 +129,28 @@ impl FuzzTestExecutor<FuzzAccounts> for FuzzInstruction {
                 transaction.sign(&sig, client.get_last_blockhash());
                 let res = client
                     .process_transaction(transaction)
-                    .map_err(|e| e.with_origin(Origin::Instruction(self.to_string())));
+                    .map_err(|e| {
+                        e.with_origin(Origin::Instruction(self.to_context_string()))
+                    });
                 snaphot.capture_after(client).unwrap();
                 let (acc_before, acc_after) = snaphot
                     .get_snapshot()
-                    .map_err(|e| e.with_origin(Origin::Instruction(self.to_string())))
+                    .map_err(|e| {
+                        e.with_origin(Origin::Instruction(self.to_context_string()))
+                    })
                     .unwrap();
                 if let Err(e)
                     = ix
                         .check(acc_before, acc_after, data)
                         .map_err(|e| {
-                            e.with_origin(Origin::Instruction(self.to_string()))
+                            e.with_origin(Origin::Instruction(self.to_context_string()))
                         })
                 {
                     {
                         ::std::io::_eprint(
                             format_args!(
                                 "Custom check after the {0} instruction did not pass with the error message: {1}\n",
-                                self, e,
+                                self.to_context_string(), e,
                             ),
                         );
                     };

--- a/examples/fuzz_example0/trdelnik-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
+++ b/examples/fuzz_example0/trdelnik-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
@@ -1,35 +1,35 @@
 pub mod fuzz_example0_fuzz_instructions {
     use crate::accounts_snapshots::*;
     use trdelnik_client::{fuzzing::*, solana_sdk::native_token::LAMPORTS_PER_SOL};
-    #[derive(Arbitrary, Clone, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
+    #[derive(Arbitrary, Debug, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
     pub enum FuzzInstruction {
         Initialize(Initialize),
         Update(Update),
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct Initialize {
         pub accounts: InitializeAccounts,
         pub data: InitializeData,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct InitializeAccounts {
         pub counter: AccountId,
         pub user: AccountId,
         pub system_program: AccountId,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct InitializeData {}
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct Update {
         pub accounts: UpdateAccounts,
         pub data: UpdateData,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct UpdateAccounts {
         pub counter: AccountId,
         pub authority: AccountId,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct UpdateData {
         pub input1: u8,
         pub input2: u8,

--- a/examples/fuzz_example0/trdelnik-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
+++ b/examples/fuzz_example0/trdelnik-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
@@ -1,7 +1,7 @@
 pub mod fuzz_example0_fuzz_instructions {
     use crate::accounts_snapshots::*;
     use trdelnik_client::{fuzzing::*, solana_sdk::native_token::LAMPORTS_PER_SOL};
-    #[derive(Arbitrary, Debug, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
+    #[derive(Arbitrary, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
     pub enum FuzzInstruction {
         Initialize(Initialize),
         Update(Update),

--- a/examples/fuzz_example1/trdelnik-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
+++ b/examples/fuzz_example1/trdelnik-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
@@ -2,7 +2,7 @@ pub mod fuzz_example1_fuzz_instructions {
     use crate::accounts_snapshots::*;
     use fuzz_example1::state::{PROJECT_SEED, STATE_SEED};
     use trdelnik_client::fuzzing::*;
-    #[derive(Arbitrary, Debug, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
+    #[derive(Arbitrary, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
     pub enum FuzzInstruction {
         Initialize(Initialize),
         Register(Register),

--- a/examples/fuzz_example1/trdelnik-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
+++ b/examples/fuzz_example1/trdelnik-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
@@ -2,19 +2,19 @@ pub mod fuzz_example1_fuzz_instructions {
     use crate::accounts_snapshots::*;
     use fuzz_example1::state::{PROJECT_SEED, STATE_SEED};
     use trdelnik_client::fuzzing::*;
-    #[derive(Arbitrary, Clone, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
+    #[derive(Arbitrary, Debug, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
     pub enum FuzzInstruction {
         Initialize(Initialize),
         Register(Register),
         EndRegistrations(EndRegistrations),
         Invest(Invest),
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct Initialize {
         pub accounts: InitializeAccounts,
         pub data: InitializeData,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct InitializeAccounts {
         #[arbitrary(with = |u: &mut arbitrary::Unstructured| u.int_in_range(0..=2))]
         pub author: AccountId,
@@ -22,14 +22,14 @@ pub mod fuzz_example1_fuzz_instructions {
         pub state: AccountId,
         pub system_program: AccountId,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct InitializeData {}
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct Register {
         pub accounts: RegisterAccounts,
         pub data: RegisterData,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct RegisterAccounts {
         #[arbitrary(with = |u: &mut arbitrary::Unstructured| u.int_in_range(0..=2))]
         pub project_author: AccountId,
@@ -39,28 +39,28 @@ pub mod fuzz_example1_fuzz_instructions {
         pub state: AccountId,
         pub system_program: AccountId,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct RegisterData {}
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct EndRegistrations {
         pub accounts: EndRegistrationsAccounts,
         pub data: EndRegistrationsData,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct EndRegistrationsAccounts {
         #[arbitrary(with = |u: &mut arbitrary::Unstructured| u.int_in_range(0..=2))]
         pub author: AccountId,
         #[arbitrary(with = |u: &mut arbitrary::Unstructured| u.int_in_range(0..=2))]
         pub state: AccountId,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct EndRegistrationsData {}
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct Invest {
         pub accounts: InvestAccounts,
         pub data: InvestData,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct InvestAccounts {
         #[arbitrary(with = |u: &mut arbitrary::Unstructured| u.int_in_range(0..=2))]
         pub investor: AccountId,
@@ -70,7 +70,7 @@ pub mod fuzz_example1_fuzz_instructions {
         pub state: AccountId,
         pub system_program: AccountId,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct InvestData {
         pub amount: u64,
     }

--- a/examples/fuzz_example2/trdelnik-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
+++ b/examples/fuzz_example2/trdelnik-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
@@ -4,7 +4,7 @@ pub mod fuzz_example2_fuzz_instructions {
     use trdelnik_client::{
         anchor_lang::Key, fuzzing::*, solana_sdk::native_token::LAMPORTS_PER_SOL,
     };
-    #[derive(Arbitrary, Debug, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
+    #[derive(Arbitrary, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
     pub enum FuzzInstruction {
         Initialize(Initialize),
         Withdraw(Withdraw),

--- a/examples/fuzz_example2/trdelnik-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
+++ b/examples/fuzz_example2/trdelnik-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
@@ -4,39 +4,39 @@ pub mod fuzz_example2_fuzz_instructions {
     use trdelnik_client::{
         anchor_lang::Key, fuzzing::*, solana_sdk::native_token::LAMPORTS_PER_SOL,
     };
-    #[derive(Arbitrary, Clone, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
+    #[derive(Arbitrary, Debug, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
     pub enum FuzzInstruction {
         Initialize(Initialize),
         Withdraw(Withdraw),
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct Initialize {
         pub accounts: InitializeAccounts,
         pub data: InitializeData,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct InitializeAccounts {
         pub author: AccountId,
         pub escrow: AccountId,
         pub system_program: AccountId,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct InitializeData {
         pub receiver: AccountId,
         pub amount: u64,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct Withdraw {
         pub accounts: WithdrawAccounts,
         pub data: WithdrawData,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct WithdrawAccounts {
         pub receiver: AccountId,
         pub escrow: AccountId,
         pub system_program: AccountId,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct WithdrawData {}
     impl<'info> IxOps<'info> for Initialize {
         type IxData = fuzz_example2::instruction::Initialize;

--- a/examples/fuzz_example3/trdelnik-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
+++ b/examples/fuzz_example3/trdelnik-tests/fuzz_tests/fuzz_0/fuzz_instructions.rs
@@ -1,17 +1,17 @@
 pub mod fuzz_example3_fuzz_instructions {
     use crate::accounts_snapshots::*;
     use trdelnik_client::{fuzzing::*, solana_sdk::native_token::LAMPORTS_PER_SOL};
-    #[derive(Arbitrary, Clone, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
+    #[derive(Arbitrary, DisplayIx, FuzzTestExecutor, FuzzDeserialize)]
     pub enum FuzzInstruction {
         InitVesting(InitVesting),
         WithdrawUnlocked(WithdrawUnlocked),
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct InitVesting {
         pub accounts: InitVestingAccounts,
         pub data: InitVestingData,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct InitVestingAccounts {
         pub sender: AccountId,
         pub sender_token_account: AccountId,
@@ -21,7 +21,7 @@ pub mod fuzz_example3_fuzz_instructions {
         pub token_program: AccountId,
         pub system_program: AccountId,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct InitVestingData {
         pub recipient: AccountId,
         #[arbitrary(with = |u: &mut arbitrary::Unstructured| u.int_in_range(1..=1_000_000))]
@@ -35,12 +35,12 @@ pub mod fuzz_example3_fuzz_instructions {
         #[arbitrary(with = |u: &mut arbitrary::Unstructured| u.int_in_range(1..=1000))]
         pub interval: u64,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct WithdrawUnlocked {
         pub accounts: WithdrawUnlockedAccounts,
         pub data: WithdrawUnlockedData,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct WithdrawUnlockedAccounts {
         pub recipient: AccountId,
         pub recipient_token_account: AccountId,
@@ -51,7 +51,7 @@ pub mod fuzz_example3_fuzz_instructions {
         pub token_program: AccountId,
         pub system_program: AccountId,
     }
-    #[derive(Arbitrary, Clone)]
+    #[derive(Arbitrary, Debug)]
     pub struct WithdrawUnlockedData {}
     impl<'info> IxOps<'info> for InitVesting {
         type IxData = fuzz_example3::instruction::InitVesting;


### PR DESCRIPTION
I would say currently the best possible option to debug the fuzzed instructions sequence is to use msg!() macro inside the solana program.

This PR makes it easier to examine data and accounts passed into instructions. Here are the improvements:

- It defaults to deriving the Debug trait for Accounts and Data structs generated by the Fuzzer.
- The DisplayIx macro is extended to also display struct contents.
- In relation to the above points, the DisplayIx macro is further extended to derive a "to_context_string()" function. This is used to obtain the instruction name since the std::fmt::Display implementation now includes the struct contents, meaning to_string() would also fetch the contents - this method is further used within the FuzzTestExecutor to obtain Error Context.
- (This may be overkill) A simple "show_account" macro is introduced, which implements pretty-print for the input account.
  - This may be used by the user for example within the check() function. The macro contains requirements inside rustdocs to derive the Debug trait for the Account Struct If the user wants to display the Account`s contents.

When we look at the data from instruction sequences, the amount of information in debug mode can be too noisy. I thought about using an additional conditional compilation to manage this. This means we could use the RUSTFLAGS environment variable to give extra instructions to the rustc compiler (used by the honggfuzz). But, doing this would mean that all the code that was compiled before would need to be compiled again, and this could take a lot of time. So, for now, I've decided to just use the fuzzing_debug flag, which is automatically turned on by the honggfuzz.