### PR TITLE
♻️ Refactored fuzz test executor error handling

### DIFF
--- a/crates/client/tests/test_data/fuzzer_macros/fuzz_fuzz_test_executor.expanded.rs
+++ b/crates/client/tests/test_data/fuzzer_macros/fuzz_fuzz_test_executor.expanded.rs
@@ -12,30 +12,20 @@ impl FuzzTestExecutor<FuzzAccounts> for FuzzInstruction {
     ) -> core::result::Result<(), Box<dyn std::error::Error + 'static>> {
         match self {
             FuzzInstruction::InitVesting(ix) => {
-                let (mut signers, metas) = if let Ok(acc)
-                    = ix
-                        .get_accounts(client, &mut accounts.borrow_mut())
-                        .map_err(|e| {
-                            e.with_origin(Origin::Instruction(self.to_context_string()))
-                        })
-                {
-                    acc
-                } else {
-                    return Ok(());
-                };
+                let (mut signers, metas) = ix
+                    .get_accounts(client, &mut accounts.borrow_mut())
+                    .map_err(|e| {
+                        e.with_origin(Origin::Instruction(self.to_context_string()))
+                    })
+                    .expect("Accounts calculation expect");
                 let mut snaphot = Snapshot::new(&metas, ix);
                 snaphot.capture_before(client).unwrap();
-                let data = if let Ok(data)
-                    = ix
-                        .get_data(client, &mut accounts.borrow_mut())
-                        .map_err(|e| {
-                            e.with_origin(Origin::Instruction(self.to_context_string()))
-                        })
-                {
-                    data
-                } else {
-                    return Ok(());
-                };
+                let data = ix
+                    .get_data(client, &mut accounts.borrow_mut())
+                    .map_err(|e| {
+                        e.with_origin(Origin::Instruction(self.to_context_string()))
+                    })
+                    .expect("Data calculation expect");
                 let ixx = Instruction {
                     program_id,
                     accounts: metas.clone(),
@@ -48,66 +38,55 @@ impl FuzzTestExecutor<FuzzAccounts> for FuzzInstruction {
                 signers.push(client.payer().clone());
                 let sig: Vec<&Keypair> = signers.iter().collect();
                 transaction.sign(&sig, client.get_last_blockhash());
-                let res = client
+                let tx_res = client
                     .process_transaction(transaction)
                     .map_err(|e| {
                         e.with_origin(Origin::Instruction(self.to_context_string()))
                     });
-                snaphot.capture_after(client).unwrap();
-                let (acc_before, acc_after) = snaphot
-                    .get_snapshot()
-                    .map_err(|e| {
-                        e.with_origin(Origin::Instruction(self.to_context_string()))
-                    })
-                    .unwrap();
-                if let Err(e)
-                    = ix
-                        .check(acc_before, acc_after, data)
+                if tx_res.is_ok() {
+                    snaphot.capture_after(client).unwrap();
+                    let (acc_before, acc_after) = snaphot
+                        .get_snapshot()
                         .map_err(|e| {
                             e.with_origin(Origin::Instruction(self.to_context_string()))
                         })
-                {
+                        .expect("Snapshot deserialization expect");
+                    if let Err(e)
+                        = ix
+                            .check(acc_before, acc_after, data)
+                            .map_err(|e| {
+                                e.with_origin(Origin::Instruction(self.to_context_string()))
+                            })
                     {
-                        ::std::io::_eprint(
-                            format_args!(
-                                "CRASH DETECTED! Custom check after the {0} instruction did not pass!\n",
-                                self.to_context_string(),
-                            ),
-                        );
-                    };
-                    {
-                        ::core::panicking::panic_display(&e);
+                        {
+                            ::std::io::_eprint(
+                                format_args!(
+                                    "CRASH DETECTED! Custom check after the {0} instruction did not pass!\n",
+                                    self.to_context_string(),
+                                ),
+                            );
+                        };
+                        {
+                            ::core::panicking::panic_display(&e);
+                        }
                     }
-                }
-                if res.is_err() {
-                    return Ok(());
                 }
             }
             FuzzInstruction::WithdrawUnlocked(ix) => {
-                let (mut signers, metas) = if let Ok(acc)
-                    = ix
-                        .get_accounts(client, &mut accounts.borrow_mut())
-                        .map_err(|e| {
-                            e.with_origin(Origin::Instruction(self.to_context_string()))
-                        })
-                {
-                    acc
-                } else {
-                    return Ok(());
-                };
+                let (mut signers, metas) = ix
+                    .get_accounts(client, &mut accounts.borrow_mut())
+                    .map_err(|e| {
+                        e.with_origin(Origin::Instruction(self.to_context_string()))
+                    })
+                    .expect("Accounts calculation expect");
                 let mut snaphot = Snapshot::new(&metas, ix);
                 snaphot.capture_before(client).unwrap();
-                let data = if let Ok(data)
-                    = ix
-                        .get_data(client, &mut accounts.borrow_mut())
-                        .map_err(|e| {
-                            e.with_origin(Origin::Instruction(self.to_context_string()))
-                        })
-                {
-                    data
-                } else {
-                    return Ok(());
-                };
+                let data = ix
+                    .get_data(client, &mut accounts.borrow_mut())
+                    .map_err(|e| {
+                        e.with_origin(Origin::Instruction(self.to_context_string()))
+                    })
+                    .expect("Data calculation expect");
                 let ixx = Instruction {
                     program_id,
                     accounts: metas.clone(),
@@ -120,39 +99,38 @@ impl FuzzTestExecutor<FuzzAccounts> for FuzzInstruction {
                 signers.push(client.payer().clone());
                 let sig: Vec<&Keypair> = signers.iter().collect();
                 transaction.sign(&sig, client.get_last_blockhash());
-                let res = client
+                let tx_res = client
                     .process_transaction(transaction)
                     .map_err(|e| {
                         e.with_origin(Origin::Instruction(self.to_context_string()))
                     });
-                snaphot.capture_after(client).unwrap();
-                let (acc_before, acc_after) = snaphot
-                    .get_snapshot()
-                    .map_err(|e| {
-                        e.with_origin(Origin::Instruction(self.to_context_string()))
-                    })
-                    .unwrap();
-                if let Err(e)
-                    = ix
-                        .check(acc_before, acc_after, data)
+                if tx_res.is_ok() {
+                    snaphot.capture_after(client).unwrap();
+                    let (acc_before, acc_after) = snaphot
+                        .get_snapshot()
                         .map_err(|e| {
                             e.with_origin(Origin::Instruction(self.to_context_string()))
                         })
-                {
+                        .expect("Snapshot deserialization expect");
+                    if let Err(e)
+                        = ix
+                            .check(acc_before, acc_after, data)
+                            .map_err(|e| {
+                                e.with_origin(Origin::Instruction(self.to_context_string()))
+                            })
                     {
-                        ::std::io::_eprint(
-                            format_args!(
-                                "CRASH DETECTED! Custom check after the {0} instruction did not pass!\n",
-                                self.to_context_string(),
-                            ),
-                        );
-                    };
-                    {
-                        ::core::panicking::panic_display(&e);
+                        {
+                            ::std::io::_eprint(
+                                format_args!(
+                                    "CRASH DETECTED! Custom check after the {0} instruction did not pass!\n",
+                                    self.to_context_string(),
+                                ),
+                            );
+                        };
+                        {
+                            ::core::panicking::panic_display(&e);
+                        }
                     }
-                }
-                if res.is_err() {
-                    return Ok(());
                 }
             }
         }


### PR DESCRIPTION
Now the `check ` method will be called only after successful transaction execution.
Also, the `get_accounts` and `get_data` methods will panic in case of error to notify the developer that the custom implementations are not correct.