### PR TITLE
Improve init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6003,6 +6003,7 @@ dependencies = [
  "futures",
  "heck 0.4.1",
  "honggfuzz",
+ "indicatif",
  "lazy_static",
  "log",
  "macrotest",

--- a/crates/cli/src/command/fuzz.rs
+++ b/crates/cli/src/command/fuzz.rs
@@ -68,7 +68,7 @@ pub async fn fuzz(root: Option<String>, subcmd: FuzzCommand) {
             // generate generator with root so that we do not need to again
             // look for root within the generator
             let mut generator = TestGenerator::new_with_root(root);
-            generator.add_fuzz_test().await?;
+            generator.generate_fuzz().await?;
         }
     };
 }

--- a/crates/cli/src/command/fuzz.rs
+++ b/crates/cli/src/command/fuzz.rs
@@ -68,7 +68,7 @@ pub async fn fuzz(root: Option<String>, subcmd: FuzzCommand) {
             // generate generator with root so that we do not need to again
             // look for root within the generator
             let mut generator = TestGenerator::new_with_root(root);
-            generator.add_new_fuzz_test().await?;
+            generator.add_fuzz_test().await?;
         }
     };
 }

--- a/crates/cli/src/command/fuzz.rs
+++ b/crates/cli/src/command/fuzz.rs
@@ -68,7 +68,7 @@ pub async fn fuzz(root: Option<String>, subcmd: FuzzCommand) {
             // generate generator with root so that we do not need to again
             // look for root within the generator
             let mut generator = TestGenerator::new_with_root(root);
-            generator.generate_fuzz().await?;
+            generator.add_fuzz_test().await?;
         }
     };
 }

--- a/crates/cli/src/command/test.rs
+++ b/crates/cli/src/command/test.rs
@@ -21,5 +21,6 @@ pub async fn test(root: Option<String>) {
         }
     };
     let commander = Commander::with_root(root);
+    commander.build_anchor_project().await?;
     commander.run_tests().await?;
 }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -69,3 +69,4 @@ trdelnik-derive-fuzz-deserialize = { path = "./derive/fuzz_deserialize" }
 trdelnik-derive-fuzz-test-executor = { path = "./derive/fuzz_test_executor" }
 pathdiff = "0.2.1"
 solana-banks-client = "<1.18"
+indicatif = "0.17.8"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -24,50 +24,49 @@ pretty_assertions = "1.1.0"
 macrotest = "1.0.9"
 
 [dependencies]
-trdelnik-derive-displayix           = { path = "./derive/display_ix" }
-trdelnik-derive-fuzz-deserialize    = { path = "./derive/fuzz_deserialize" }
-trdelnik-derive-fuzz-test-executor  = { path = "./derive/fuzz_test_executor" }
-trdelnik-test                       = { workspace = true }
+trdelnik-derive-displayix = { path = "./derive/display_ix" }
+trdelnik-derive-fuzz-deserialize = { path = "./derive/fuzz_deserialize" }
+trdelnik-derive-fuzz-test-executor = { path = "./derive/fuzz_test_executor" }
+trdelnik-test = { workspace = true }
 # INFO: This is a hack! Anchor-spl is here as dependency only to activate the idl-build feature, so that
 # users do not have to do it manually in their program's Cargo.toml
-anchor-spl                          = { version = "0.29.0", features = ["idl-build"] }
-anchor-lang                         = { version = "0.29.0", features = ["idl-build"] }
-solana-sdk                          = { workspace = true }
-solana-cli-output                   = { workspace = true }
-solana-transaction-status           = { workspace = true }
-solana-account-decoder              = { workspace = true }
-anchor-client                       = { workspace = true }
-spl-token                           = { workspace = true }
-spl-associated-token-account        = { workspace = true }
-tokio                               = { workspace = true }
-rand                                = { workspace = true }
-serde_json                          = { workspace = true }
-serde                               = { workspace = true }
-bincode                             = { workspace = true }
-borsh                               = { workspace = true }
-futures                             = { workspace = true }
-fehler                              = { workspace = true }
-thiserror                           = { workspace = true }
-ed25519-dalek                       = { workspace = true }
-serial_test                         = { workspace = true }
-anyhow                              = { workspace = true }
-cargo_metadata                      = { workspace = true }
-syn                                 = { workspace = true }
-quote                               = { workspace = true }
-heck                                = { workspace = true }
-toml                                = { workspace = true }
-log                                 = { workspace = true }
-rstest                              = { workspace = true }
-lazy_static                         = { workspace = true }
-proc-macro2                         = { workspace = true }
-arbitrary                           = { version = "1.3.0", features = ["derive"] }
-honggfuzz                           = { version = "0.5.55", optional = true }
+anchor-spl = { version = "0.29.0", features = ["idl-build"] }
+anchor-lang = { version = "0.29.0", features = ["idl-build"] }
+solana-sdk = { workspace = true }
+solana-cli-output = { workspace = true }
+solana-transaction-status = { workspace = true }
+solana-account-decoder = { workspace = true }
+anchor-client = { workspace = true }
+spl-token = { workspace = true }
+spl-associated-token-account = { workspace = true }
+tokio = { workspace = true }
+rand = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }
+bincode = { workspace = true }
+borsh = { workspace = true }
+futures = { workspace = true }
+fehler = { workspace = true }
+thiserror = { workspace = true }
+ed25519-dalek = { workspace = true }
+serial_test = { workspace = true }
+anyhow = { workspace = true }
+cargo_metadata = { workspace = true }
+syn = { workspace = true }
+quote = { workspace = true }
+heck = { workspace = true }
+toml = { workspace = true }
+log = { workspace = true }
+rstest = { workspace = true }
+lazy_static = { workspace = true }
+proc-macro2 = { workspace = true }
+honggfuzz = { version = "0.5.55", optional = true }
+arbitrary = { version = "1.3.0", features = ["derive"] }
+solana-program-test-anchor-fix = { version = "1.17.9", optional = true }
 # solana-program-test = { version = "=1.17.16", optional = true }
 quinn-proto = { version = "0.10.6", optional = true }
 solana-program-runtime = { version = "<1.18", optional = true }
 shellexpand = { workspace = true }
-
 pathdiff = "0.2.1"
 solana-banks-client = "<1.18"
 indicatif = "0.17.8"
-solana-program-test-anchor-fix      = {version = "1.17.9", optional = true}

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -24,49 +24,50 @@ pretty_assertions = "1.1.0"
 macrotest = "1.0.9"
 
 [dependencies]
-trdelnik-test = { workspace = true }
-anchor-lang = { version = "0.29.0", features = ["idl-build"] }
+trdelnik-derive-displayix           = { path = "./derive/display_ix" }
+trdelnik-derive-fuzz-deserialize    = { path = "./derive/fuzz_deserialize" }
+trdelnik-derive-fuzz-test-executor  = { path = "./derive/fuzz_test_executor" }
+trdelnik-test                       = { workspace = true }
 # INFO: This is a hack! Anchor-spl is here as dependency only to activate the idl-build feature, so that
 # users do not have to do it manually in their program's Cargo.toml
-anchor-spl = { version = "0.29.0", features = ["idl-build"] }
-solana-sdk = { workspace = true }
-solana-cli-output = { workspace = true }
-solana-transaction-status = { workspace = true }
-solana-account-decoder = { workspace = true }
-anchor-client = { workspace = true }
-spl-token = { workspace = true }
-spl-associated-token-account = { workspace = true }
-tokio = { workspace = true }
-rand = { workspace = true }
-serde_json = { workspace = true }
-serde = { workspace = true }
-bincode = { workspace = true }
-borsh = { workspace = true }
-futures = { workspace = true }
-fehler = { workspace = true }
-thiserror = { workspace = true }
-ed25519-dalek = { workspace = true }
-serial_test = { workspace = true }
-anyhow = { workspace = true }
-cargo_metadata = { workspace = true }
-syn = { workspace = true }
-quote = { workspace = true }
-heck = { workspace = true }
-toml = { workspace = true }
-log = { workspace = true }
-rstest = { workspace = true }
-lazy_static = { workspace = true }
-proc-macro2 = { workspace = true }
-honggfuzz = { version = "0.5.55", optional = true }
-arbitrary = { version = "1.3.0", features = ["derive"] }
+anchor-spl                          = { version = "0.29.0", features = ["idl-build"] }
+anchor-lang                         = { version = "0.29.0", features = ["idl-build"] }
+solana-sdk                          = { workspace = true }
+solana-cli-output                   = { workspace = true }
+solana-transaction-status           = { workspace = true }
+solana-account-decoder              = { workspace = true }
+anchor-client                       = { workspace = true }
+spl-token                           = { workspace = true }
+spl-associated-token-account        = { workspace = true }
+tokio                               = { workspace = true }
+rand                                = { workspace = true }
+serde_json                          = { workspace = true }
+serde                               = { workspace = true }
+bincode                             = { workspace = true }
+borsh                               = { workspace = true }
+futures                             = { workspace = true }
+fehler                              = { workspace = true }
+thiserror                           = { workspace = true }
+ed25519-dalek                       = { workspace = true }
+serial_test                         = { workspace = true }
+anyhow                              = { workspace = true }
+cargo_metadata                      = { workspace = true }
+syn                                 = { workspace = true }
+quote                               = { workspace = true }
+heck                                = { workspace = true }
+toml                                = { workspace = true }
+log                                 = { workspace = true }
+rstest                              = { workspace = true }
+lazy_static                         = { workspace = true }
+proc-macro2                         = { workspace = true }
+arbitrary                           = { version = "1.3.0", features = ["derive"] }
+honggfuzz                           = { version = "0.5.55", optional = true }
 # solana-program-test = { version = "=1.17.16", optional = true }
-solana-program-test-anchor-fix = { version = "1.17.9", optional = true }
 quinn-proto = { version = "0.10.6", optional = true }
 solana-program-runtime = { version = "<1.18", optional = true }
 shellexpand = { workspace = true }
-trdelnik-derive-displayix = { path = "./derive/display_ix" }
-trdelnik-derive-fuzz-deserialize = { path = "./derive/fuzz_deserialize" }
-trdelnik-derive-fuzz-test-executor = { path = "./derive/fuzz_test_executor" }
+
 pathdiff = "0.2.1"
 solana-banks-client = "<1.18"
 indicatif = "0.17.8"
+solana-program-test-anchor-fix      = {version = "1.17.9", optional = true}

--- a/crates/client/src/cleaner.rs
+++ b/crates/client/src/cleaner.rs
@@ -7,6 +7,8 @@ use std::{
 use thiserror::Error;
 use tokio::{fs, process::Command};
 
+use crate::constants::*;
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("{0:?}")]
@@ -44,19 +46,16 @@ impl Cleaner {
     #[throws]
     async fn clean_hfuzz_target(&self, root: &PathBuf) {
         let hfuzz_target_path = Path::new(root)
-            .join(crate::test_generator::TESTS_WORKSPACE)
-            .join(crate::test_generator::FUZZ_TEST_DIRECTORY)
-            .join(crate::test_generator::FUZZING)
-            .join(crate::test_generator::HFUZZ_TARGET);
+            .join(TESTS_WORKSPACE_DIRECTORY)
+            .join(FUZZ_TEST_DIRECTORY)
+            .join(FUZZING)
+            .join(HFUZZ_TARGET);
         if hfuzz_target_path.exists() {
             fs::remove_dir_all(hfuzz_target_path).await?;
         } else {
             println!(
                 "skipping {}/{}/{}/{} directory: not found",
-                crate::test_generator::TESTS_WORKSPACE,
-                crate::test_generator::FUZZ_TEST_DIRECTORY,
-                crate::test_generator::FUZZING,
-                crate::test_generator::HFUZZ_TARGET
+                TESTS_WORKSPACE_DIRECTORY, FUZZ_TEST_DIRECTORY, FUZZING, HFUZZ_TARGET
             )
         }
     }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -36,8 +36,7 @@ use std::{thread::sleep, time::Duration};
 // @TODO: Make compatible with the latest Anchor deps.
 // https://github.com/project-serum/anchor/pull/1307#issuecomment-1022592683
 
-const RETRY_LOCALNET_EVERY_MILLIS: u64 = 500;
-const DEFAULT_KEYPAIR_PATH: &str = "~/.config/solana/id.json";
+use crate::constants::*;
 
 type Payer = Rc<Keypair>;
 

--- a/crates/client/src/commander.rs
+++ b/crates/client/src/commander.rs
@@ -110,15 +110,10 @@ impl Commander {
         Self { root: root.into() }
     }
 
-    /// Builds programs (smart contracts).
     #[throws]
-    pub async fn build_programs(&self) {
-        let success = Command::new("cargo")
-            .arg("build-bpf")
-            .arg("--")
-            // prevent prevent dependency loop:
-            // program tests -> program_client -> program
-            .args(["-Z", "avoid-dev-deps"])
+    pub async fn build_anchor_project(&self) {
+        let success = Command::new("anchor")
+            .arg("build")
             .spawn()?
             .wait()
             .await?
@@ -127,7 +122,6 @@ impl Commander {
             throw!(Error::BuildProgramsFailed);
         }
     }
-
     /// Runs standard Rust tests.
     ///
     /// _Note_: The [--nocapture](https://doc.rust-lang.org/cargo/commands/cargo-test.html#display-options) argument is used

--- a/crates/client/src/config.rs
+++ b/crates/client/src/config.rs
@@ -4,14 +4,7 @@ use serde::Deserialize;
 use std::{collections::HashMap, env, fs, io, path::PathBuf};
 use thiserror::Error;
 
-pub const CARGO_TOML: &str = "Cargo.toml";
-pub const TRDELNIK_TOML: &str = "Trdelnik.toml";
-pub const ANCHOR_TOML: &str = "Anchor.toml";
-pub const CARGO_TARGET_DIR_DEFAULT: &str = "trdelnik-tests/fuzz_tests/fuzzing/hfuzz_target";
-pub const HFUZZ_WORKSPACE_DEFAULT: &str = "trdelnik-tests/fuzz_tests/fuzzing/hfuzz_workspace";
-
-pub const CARGO_TARGET_DIR_ENV: &str = "CARGO_TARGET_DIR";
-pub const HFUZZ_WORKSPACE_ENV: &str = "HFUZZ_WORKSPACE";
+use crate::constants::*;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/crates/client/src/fuzzer/fuzzer_generator.rs
+++ b/crates/client/src/fuzzer/fuzzer_generator.rs
@@ -11,9 +11,9 @@ pub fn generate_source_code(idl: &Idl) -> String {
         .programs
         .iter()
         .map(|idl_program| {
-            let program_name = idl_program.name.snake_case.replace('-', "_");
+            let program_name = &idl_program.name.snake_case;
             let fuzz_instructions_module_name = format_ident!("{}_fuzz_instructions", program_name);
-            let module_name: syn::Ident = parse_str(&program_name).unwrap();
+            let module_name: syn::Ident = parse_str(program_name).unwrap();
 
             let instructions = idl_program
                 .instruction_account_pairs

--- a/crates/client/src/idl.rs
+++ b/crates/client/src/idl.rs
@@ -188,32 +188,32 @@ pub struct Idl {
     pub programs: Vec<IdlProgram>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IdlName {
     pub snake_case: String,
     pub upper_camel_case: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IdlProgram {
     pub name: IdlName,
     pub id: String,
     pub instruction_account_pairs: Vec<(IdlInstruction, IdlAccountGroup)>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IdlInstruction {
     pub name: IdlName,
     pub parameters: Vec<(String, String)>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IdlAccountGroup {
     pub name: IdlName,
     pub accounts: Vec<(String, String)>,
 }
 
-pub async fn parse_to_idl_program(name: String, code: &str) -> Result<IdlProgram, Error> {
+pub fn parse_to_idl_program(name: String, code: &str) -> Result<IdlProgram, Error> {
     let mut static_program_id = None::<syn::ItemStatic>;
     let mut mod_private = None::<syn::ItemMod>;
     let mut mod_instruction = None::<syn::ItemMod>;
@@ -638,7 +638,7 @@ pub async fn parse_to_idl_program(name: String, code: &str) -> Result<IdlProgram
     Ok(IdlProgram {
         name: IdlName {
             upper_camel_case: name.to_upper_camel_case(),
-            snake_case: name,
+            snake_case: name.to_snake_case(),
         },
         id: program_id_bytes.into_token_stream().to_string(),
         instruction_account_pairs,

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -132,7 +132,6 @@ mod constants {
 
     // workspace
     pub const GIT_IGNORE: &str = ".gitignore";
-    pub const MANIFEST_PATH: &str = env!("CARGO_MANIFEST_DIR");
 
     // client
     pub const RETRY_LOCALNET_EVERY_MILLIS: u64 = 500;

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -98,3 +98,43 @@ pub use cleaner::*;
 pub use trdelnik_derive_displayix::DisplayIx;
 pub use trdelnik_derive_fuzz_deserialize::FuzzDeserialize;
 pub use trdelnik_derive_fuzz_test_executor::FuzzTestExecutor;
+
+mod constants {
+    // program_client
+    pub const PROGRAM_CLIENT_DIRECTORY: &str = ".program_client";
+    pub const LIB: &str = "lib.rs";
+    pub const SRC_DIRECTORY: &str = "src";
+
+    // tomls
+    pub const CARGO_TOML: &str = "Cargo.toml";
+    pub const TRDELNIK_TOML: &str = "Trdelnik.toml";
+    pub const ANCHOR_TOML: &str = "Anchor.toml";
+
+    // tests
+    pub const TESTS_WORKSPACE_DIRECTORY: &str = "trdelnik-tests";
+
+    // poc
+    pub const POC_TEST_DIRECTORY: &str = "poc_tests";
+    pub const TESTS_DIRECTORY: &str = "tests";
+    pub const POC_TEST: &str = "test.rs";
+
+    // fuzz
+    pub const ACCOUNTS_SNAPSHOTS_FILE_NAME: &str = "accounts_snapshots.rs";
+    pub const FUZZ_INSTRUCTIONS_FILE_NAME: &str = "fuzz_instructions.rs";
+    pub const FUZZ_TEST_DIRECTORY: &str = "fuzz_tests";
+    pub const FUZZING: &str = "fuzzing";
+    pub const FUZZ_TEST: &str = "test_fuzz.rs";
+    pub const HFUZZ_TARGET: &str = "hfuzz_target";
+    pub const CARGO_TARGET_DIR_DEFAULT: &str = "trdelnik-tests/fuzz_tests/fuzzing/hfuzz_target";
+    pub const HFUZZ_WORKSPACE_DEFAULT: &str = "trdelnik-tests/fuzz_tests/fuzzing/hfuzz_workspace";
+    pub const CARGO_TARGET_DIR_ENV: &str = "CARGO_TARGET_DIR";
+    pub const HFUZZ_WORKSPACE_ENV: &str = "HFUZZ_WORKSPACE";
+
+    // workspace
+    pub const GIT_IGNORE: &str = ".gitignore";
+    pub const MANIFEST_PATH: &str = env!("CARGO_MANIFEST_DIR");
+
+    // client
+    pub const RETRY_LOCALNET_EVERY_MILLIS: u64 = 500;
+    pub const DEFAULT_KEYPAIR_PATH: &str = "~/.config/solana/id.json";
+}

--- a/crates/client/src/program_client_generator.rs
+++ b/crates/client/src/program_client_generator.rs
@@ -12,9 +12,9 @@ pub fn generate_source_code(idl: &Idl, use_modules: &[syn::ItemUse]) -> String {
         .programs
         .iter()
         .map(|idl_program| {
-            let program_name = idl_program.name.snake_case.replace('-', "_");
+            let program_name = &idl_program.name.snake_case;
             let instruction_module_name = format_ident!("{}_instruction", program_name);
-            let module_name: syn::Ident = parse_str(&program_name).unwrap();
+            let module_name: syn::Ident = parse_str(program_name).unwrap();
             let pubkey_bytes: syn::ExprArray = parse_str(&idl_program.id).unwrap();
 
             let instructions = idl_program

--- a/crates/client/src/templates/program_client/Cargo.toml.tmpl
+++ b/crates/client/src/templates/program_client/Cargo.toml.tmpl
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies.trdelnik-client]
-trdelnik-client = "0.5.0"
+version = "0.5.0"

--- a/crates/client/src/templates/program_client/Cargo.toml.tmpl
+++ b/crates/client/src/templates/program_client/Cargo.toml.tmpl
@@ -3,4 +3,5 @@ name = "program_client"
 version = "0.1.0"
 edition = "2018"
 
-[dependencies]
+[dependencies.trdelnik-client]
+trdelnik-client = "0.5.0"

--- a/crates/client/src/templates/trdelnik-tests/Cargo_poc.toml.tmpl
+++ b/crates/client/src/templates/trdelnik-tests/Cargo_poc.toml.tmpl
@@ -4,6 +4,10 @@ version = "0.1.0"
 description = "Created with Trdelnik"
 edition = "2021"
 
+# Dependencies specific to PoC test
+# Dev-dependencies are used for compiling tests,
+[dev-dependencies]
+fehler = "1.0.0"
 
 [dev-dependencies.trdelnik-client]
 version = "0.5.0"
@@ -11,9 +15,3 @@ version = "0.5.0"
 
 [dev-dependencies.program_client]
 path = "../../.program_client"
-
-
-[dependencies]
-assert_matches = "1.4.0"
-fehler = "1.0.0"
-rstest = "0.12.0"

--- a/crates/client/src/test_generator.rs
+++ b/crates/client/src/test_generator.rs
@@ -40,6 +40,67 @@ pub enum Error {
     ParsingCargoTomlDependenciesFailed,
 }
 
+/// Constructs a `PathBuf` from a given root and a series of path components.
+///
+/// This macro simplifies the creation of a `PathBuf` from multiple strings or string slices,
+/// starting with a root path and appending each subsequent component in order. It's useful for
+/// dynamically constructing file or directory paths in a more readable manner.
+///
+/// # Syntax
+/// `construct_path!(root, component1, component2, ..., componentN)`
+///
+/// - `root`: The base path from which to start. Can be a `PathBuf` or any type that implements
+///   `Into<PathBuf>`, such as a string or string slice.
+/// - `component1` to `componentN`: These are the components to be joined to the root path. Each
+///   can be any type that implements `Into<PathBuf>`, allowing for flexible path construction.
+///
+/// # Returns
+/// - Returns a `PathBuf` representing the combined path.
+///
+/// # Examples
+/// Basic usage:
+///
+/// ```
+/// # #[macro_use] extern crate trdelnik_client;
+/// # fn main() {
+/// use std::path::PathBuf;
+///
+/// // Constructs a PathBuf from a series of string slices
+/// let path = construct_path!(PathBuf::from("/tmp"), "my_project", "src", "main.rs");
+/// assert_eq!(path, PathBuf::from("/tmp/my_project/src/main.rs"));
+/// # }
+/// ```
+///
+/// Note: Replace `your_crate_name` with the name of your crate where this macro is defined.
+
+#[macro_export]
+macro_rules! construct_path {
+    ($root:expr, $($component:expr),*) => {
+        {
+            let mut path = $root.to_owned();
+            $(path = path.join($component);)*
+            path
+        }
+    };
+}
+
+/// Represents a generator for creating tests.
+///
+/// This struct is designed to hold all necessary information for generating
+/// test cases for a project. It includes paths to project components,
+/// interface definitions, and additional configuration for code generation.
+///
+/// # Fields
+/// - `root`: A `PathBuf` indicating the root directory of the project for which tests are being generated.
+/// This path is used as a base for any relative paths within the project.
+/// - `idl`: An `Idl` struct. This field is used to understand the interfaces
+/// and data structures that tests may need to interact with.
+/// - `codes_libs_pairs`: A vector of tuples, each containing a `String` and a `Utf8PathBuf`.
+/// Each tuple represents a pair of code and the package path associated with it.
+/// - `packages`: A vector of `Package` structs, representing the different packages
+/// that make up the project.
+/// - `use_tokens`: A vector of `ItemUse` tokens from the Rust syntax, representing `use` statements that
+/// should be included in the generated code for .program_client.
 pub struct TestGenerator {
     pub root: PathBuf,
     pub idl: Idl,
@@ -51,16 +112,6 @@ impl Default for TestGenerator {
     fn default() -> Self {
         Self::new()
     }
-}
-
-macro_rules! construct_path {
-    ($root:expr, $($component:expr),*) => {
-        {
-            let mut path = $root.to_owned();
-            $(path = path.join($component);)*
-            path
-        }
-    };
 }
 
 impl TestGenerator {
@@ -96,23 +147,26 @@ impl TestGenerator {
             use_tokens: Vec::default(),
         }
     }
-
-    /// Generates both proof of concept (POC) and fuzz tests along with necessary scaffolding.
+    /// Generates both proof of concept (POC) and fuzz tests along with the necessary setup.
     #[throws]
     pub async fn generate_both(&mut self) {
+        let root_path = self.root.to_str().unwrap().to_string();
+        let commander = Commander::with_root(root_path);
+        // build first
+        commander.build_anchor_project().await?;
         // expands programs within programs folder
         self.expand_programs().await?;
         // expands program_client and obtains
         // use statements
         // if program_client is not yet initialized
         // use statements are set to default
-        self.expand_program_client().await?;
-        // add/update program_client
-        self.add_program_client().await?;
-        // add poc test
-        self.add_new_poc_test().await?;
-        // add fuzz test
-        self.add_new_fuzz_test().await?;
+        self.get_program_client_imports().await?;
+        // initialize program client if it is not yet initialized
+        self.init_program_client().await?;
+        // initialize poc tests if thay are not yet initialized
+        self.init_poc_tests().await?;
+        // initialize fuzz tests if thay are not yet initialized
+        self.init_fuzz_tests().await?;
         // add trdelnik.toml
         self.create_trdelnik_manifest().await?;
         // update gitignore
@@ -122,10 +176,14 @@ impl TestGenerator {
     /// Generates fuzz tests along with the necessary setup.
     #[throws]
     pub async fn generate_fuzz(&mut self) {
+        let root_path = self.root.to_str().unwrap().to_string();
+        let commander = Commander::with_root(root_path);
+        // build first
+        commander.build_anchor_project().await?;
         // expand programs
         self.expand_programs().await?;
-        // generate fuzz test
-        self.add_new_fuzz_test().await?;
+        // initialize fuzz tests if thay are not yet initialized
+        self.init_fuzz_tests().await?;
         // add trdelnik.toml
         self.create_trdelnik_manifest().await?;
         // update gitignore
@@ -134,39 +192,155 @@ impl TestGenerator {
     /// Generates proof of concept (POC) tests along with the necessary setup.
     #[throws]
     pub async fn generate_poc(&mut self) {
+        let root_path = self.root.to_str().unwrap().to_string();
+        let commander = Commander::with_root(root_path);
+        // build first
+        commander.build_anchor_project().await?;
         // expand programs
         self.expand_programs().await?;
         // expand program_client
-        self.expand_program_client().await?;
-        // add/update program_client
-        self.add_program_client().await?;
-        // add poc test
-        self.add_new_poc_test().await?;
+        self.get_program_client_imports().await?;
+        // initialize program client if it is not yet initialized
+        self.init_program_client().await?;
+        // initialize poc tests if thay are not yet initialized
+        self.init_poc_tests().await?;
         // add trdelnik.toml
         self.create_trdelnik_manifest().await?;
     }
+
+    /// Adds new fuzz test. This means create new directory within the
+    /// trdelnik-tests/fuzz_tests directory, generate necessary files
+    /// for fuzzing (instructions and snapshots) and modify
+    /// trdelnik-tests/fuzz_tests/Cargo.toml with the new generated
+    /// fuzz test binary.
+    #[throws]
+    pub async fn add_fuzz_test(&mut self) {
+        let root_path = self.root.to_str().unwrap().to_string();
+        let commander = Commander::with_root(root_path);
+        // build first
+        commander.build_anchor_project().await?;
+        // expand programs
+        self.expand_programs().await?;
+        // initialize fuzz tests if thay are not yet initialized
+        self.add_new_fuzz_test().await?;
+        // add trdelnik.toml
+        self.create_trdelnik_manifest().await?;
+        // update gitignore
+        self.update_gitignore(CARGO_TARGET_DIR_DEFAULT)?;
+    }
+    /// Performs anchor build command and modify .program_client
+    /// folder based on the updated program contents. If the .program_client
+    /// is not yet generated, this will also generate the crate.
     #[throws]
     pub async fn build(&mut self) {
+        let root_path = self.root.to_str().unwrap().to_string();
+        let commander = Commander::with_root(root_path);
+        // build first
+        commander.build_anchor_project().await?;
         // expand programs
         self.expand_programs().await?;
         // expand program_client
-        self.expand_program_client().await?;
+        self.get_program_client_imports().await?;
         // add/update program_client
         self.add_program_client().await?;
     }
-    /// Gathers and expands program data necessary for generating tests.
+    /// Collect program packages within the programs folder.
+    /// Call rustc +nightly command in order to expand program macros, then parse
+    /// the expanded code and obtain necessary data for generating test files
     #[throws]
     async fn expand_programs(&mut self) {
         self.packages = Commander::collect_program_packages().await?;
         (self.idl, self.codes_libs_pairs) =
             Commander::expand_program_packages(&self.packages).await?;
     }
+    /// Expand .program_client source code and obtain its use statements.
     #[throws]
-    async fn expand_program_client(&mut self) {
-        self.use_tokens = Commander::expand_program_client().await?;
+    async fn get_program_client_imports(&mut self) {
+        self.use_tokens = Commander::get_program_client_imports().await?;
     }
 
-    /// Adds a new proof of concept (POC) test to the test workspace.
+    /// Checks if the whole folder structure for .program_client is already
+    /// present, if not create/update .program_client crate with the necessary files.
+    #[throws]
+    async fn init_program_client(&mut self) {
+        let cargo_path = construct_path!(self.root, PROGRAM_CLIENT_DIRECTORY, CARGO_TOML);
+        let src_path = construct_path!(self.root, PROGRAM_CLIENT_DIRECTORY, SRC_DIRECTORY);
+        let crate_path = construct_path!(self.root, PROGRAM_CLIENT_DIRECTORY);
+        let lib_path = construct_path!(self.root, PROGRAM_CLIENT_DIRECTORY, SRC_DIRECTORY, LIB);
+
+        if cargo_path.exists() && src_path.exists() && crate_path.exists() && lib_path.exists() {
+            println!("\x1b[93mSkipping\x1b[0m: looks like .program_client is already initialized.");
+        } else {
+            self.add_program_client().await?;
+        }
+    }
+
+    // Checks if whole Fuzz Test folder structer is already initialized,
+    // and if fuzz_tests directory contains anything except Cargo.toml and fuzzing folder
+    // if so the function does not proceed with Fuzz inicialization
+    #[throws]
+    async fn init_fuzz_tests(&mut self) {
+        // create reuqired paths
+        let fuzz_dir_path =
+            construct_path!(self.root, TESTS_WORKSPACE_DIRECTORY, FUZZ_TEST_DIRECTORY);
+        let fuzz_tests_manifest_path = construct_path!(fuzz_dir_path, CARGO_TOML);
+
+        if fuzz_dir_path.exists() {
+            // obtain directory contents
+            let mut directories: std::collections::HashSet<_> = fuzz_dir_path
+                .read_dir()
+                .expect("Reading directory failed")
+                .map(|r| {
+                    r.expect("Reading directory; DirEntry error")
+                        .file_name()
+                        .to_string_lossy()
+                        .to_string()
+                })
+                .collect();
+            directories.retain(|x| x != "fuzzing");
+            directories.retain(|x| x != CARGO_TOML);
+            // if folder structure exists and fuzz_tests directory is not empty we skip
+            if fuzz_tests_manifest_path.exists() && !directories.is_empty() {
+                println!("\x1b[93mSkipping\x1b[0m: looks like Fuzz Tests are already initialized.");
+            } else {
+                self.add_new_fuzz_test().await?
+            }
+        } else {
+            self.add_new_fuzz_test().await?
+        }
+    }
+
+    // Checks if whole PoC Test folder structer is already initialized, if so
+    // the function does not proceed with PoC inicialization
+    #[throws]
+    async fn init_poc_tests(&mut self) {
+        // create reuqired paths
+
+        let poc_dir_path =
+            construct_path!(self.root, TESTS_WORKSPACE_DIRECTORY, POC_TEST_DIRECTORY);
+        let new_poc_test_dir = construct_path!(poc_dir_path, TESTS_DIRECTORY);
+        let cargo_path = construct_path!(poc_dir_path, CARGO_TOML);
+        let poc_test_path = construct_path!(new_poc_test_dir, POC_TEST);
+
+        // if folder structure exists we skip
+        if poc_dir_path.exists()
+            && new_poc_test_dir.exists()
+            && cargo_path.exists()
+            && poc_test_path.exists()
+        {
+            println!("\x1b[93mSkipping\x1b[0m: looks like PoC Tests are already initialized.");
+        } else {
+            self.add_new_poc_test().await?;
+        }
+    }
+
+    /// Adds new PoC Test (This will Generate only one PoC Test file).
+    /// If not present create trdelnik-tests directory.
+    /// If not present create poc_tests directory.
+    /// If not present create tests directory.
+    /// If not present generate PoC test file.
+    /// If not present add program dependencies into the Cargo.toml file inside poc_tests folder
+    /// If not present add poc_tests into the workspace virtual manifest as member
     #[throws]
     async fn add_new_poc_test(&self) {
         let program_name = if !&self.idl.programs.is_empty() {
@@ -203,36 +377,15 @@ impl TestGenerator {
         self.add_program_dependencies(&poc_dir_path, "dev-dependencies", None)
             .await?;
     }
-    /// ## Creates program client folder and generates source code
-    #[throws]
-    async fn add_program_client(&self) {
-        let cargo_path = construct_path!(self.root, PROGRAM_CLIENT_DIRECTORY, CARGO_TOML);
-        let src_path = construct_path!(self.root, PROGRAM_CLIENT_DIRECTORY, SRC_DIRECTORY);
-        let crate_path = construct_path!(self.root, PROGRAM_CLIENT_DIRECTORY);
-        let lib_path = construct_path!(self.root, PROGRAM_CLIENT_DIRECTORY, SRC_DIRECTORY, LIB);
 
-        self.create_directory_all(&src_path).await?;
-
-        // load template
-        let cargo_toml_content = load_template("/src/templates/program_client/Cargo.toml.tmpl")?;
-
-        // if path exists the file will not be overwritten
-        self.create_file(&cargo_path, &cargo_toml_content).await?;
-
-        self.add_program_dependencies(&crate_path, "dependencies", Some(vec!["no-entrypoint"]))
-            .await?;
-
-        let program_client =
-            program_client_generator::generate_source_code(&self.idl, &self.use_tokens);
-        let program_client = Commander::format_program_code(&program_client).await?;
-
-        if lib_path.exists() {
-            self.update_file(&lib_path, &program_client).await?;
-        } else {
-            self.create_file(&lib_path, &program_client).await?;
-        }
-    }
-    /// Creates the `trdelnik-tests` workspace with `src/bin` directory and empty `fuzz_target.rs` file
+    /// Adds new Fuzz Test.
+    /// If not present create trdelnik-tests directory.
+    /// If not present create fuzz_tests directory.
+    /// Obtain name for the new fuzz test and generate new fuzz test
+    /// directory inside fuzz_tests folder.
+    /// Generate fuzz test files and update Cargo.toml with the new Fuzz Test binary path.
+    /// If not present add program dependencies into the Cargo.toml file inside fuzz_tests folder
+    /// If not present add fuzz_tests into the workspace virtual manifest as member
     #[throws]
     pub async fn add_new_fuzz_test(&self) {
         let program_name = if !&self.idl.programs.is_empty() {
@@ -333,7 +486,44 @@ impl TestGenerator {
         .await?;
     }
 
-    /// Creates the `Trdelnik.toml` file
+    /// Add/Update .program_client
+    /// If not present create .program_client directory.
+    /// If not present create src directory.
+    /// If not present create Cargo.toml file
+    /// If not present add program dependencies into the Cargo.toml file inside .program_client folder
+    /// Generate .program_client code.
+    /// If not present add .program_client code
+    /// If present update .program_client code
+    #[throws]
+    async fn add_program_client(&self) {
+        let cargo_path = construct_path!(self.root, PROGRAM_CLIENT_DIRECTORY, CARGO_TOML);
+        let src_path = construct_path!(self.root, PROGRAM_CLIENT_DIRECTORY, SRC_DIRECTORY);
+        let crate_path = construct_path!(self.root, PROGRAM_CLIENT_DIRECTORY);
+        let lib_path = construct_path!(self.root, PROGRAM_CLIENT_DIRECTORY, SRC_DIRECTORY, LIB);
+
+        self.create_directory_all(&src_path).await?;
+
+        // load template
+        let cargo_toml_content = load_template("/src/templates/program_client/Cargo.toml.tmpl")?;
+
+        // if path exists the file will not be overwritten
+        self.create_file(&cargo_path, &cargo_toml_content).await?;
+
+        self.add_program_dependencies(&crate_path, "dependencies", Some(vec!["no-entrypoint"]))
+            .await?;
+
+        let program_client =
+            program_client_generator::generate_source_code(&self.idl, &self.use_tokens);
+        let program_client = Commander::format_program_code(&program_client).await?;
+
+        if lib_path.exists() {
+            self.update_file(&lib_path, &program_client).await?;
+        } else {
+            self.create_file(&lib_path, &program_client).await?;
+        }
+    }
+
+    /// If not present create Trdelnik manifest with the templte.
     #[throws]
     async fn create_trdelnik_manifest(&self) {
         let trdelnik_toml_path = construct_path!(self.root, TRDELNIK_TOML);
@@ -341,6 +531,26 @@ impl TestGenerator {
         self.create_file(&trdelnik_toml_path, &trdelnik_toml_content)
             .await?;
     }
+    /// Adds a new member to the Cargo workspace manifest (`Cargo.toml`).
+    ///
+    /// This function updates the `Cargo.toml` file located at the root of the Cargo workspace
+    /// by adding a new member to the `members` array within the `[workspace]` table. If the specified member
+    /// already exists in the `members` array, the function will skip the addition and print a message indicating
+    /// that the member is already present. Otherwise, it will add the new member and print a success message.
+    ///
+    /// # Parameters
+    /// - `&self`: A reference to the current instance of the TestGenerator struct that holds the workspace root path.
+    /// - `member`: A string slice (`&str`) representing the path to the new member to be added. This path should be
+    /// relative to the workspace root.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - The `Cargo.toml` file cannot be found, read, or is not properly formatted.
+    /// - The `Cargo.toml` file does not contain a `[workspace]` table or a `members` array within that table,
+    /// and it cannot be created.
+    ///
+    /// The function uses `Error::CannotParseCargoToml` to indicate failures related to parsing or updating the
+    /// `Cargo.toml` file.
     #[throws]
     async fn add_workspace_member(&self, member: &str) {
         let cargo = construct_path!(self.root, CARGO_TOML);
@@ -365,13 +575,14 @@ impl TestGenerator {
             }
             None => {
                 members.push(new_member);
-                println!("\x1b[92mSuccesfully\x1b[0m updated: {CARGO_TOML} with {member} member.");
+                println!("\x1b[92mSuccessfully\x1b[0m updated: {CARGO_TOML} with {member} member.");
                 fs::write(cargo, content.to_string()).await?;
             }
         };
     }
 
-    /// ## Creates a new directory and all missing parent directories on the specified path
+    /// If not present creates a new directory and all missing
+    /// parent directories on the specified path
     #[throws]
     async fn create_directory_all(&self, path: &PathBuf) {
         match path.exists() {
@@ -381,7 +592,7 @@ impl TestGenerator {
             }
         };
     }
-    /// ## Creates directory with specified path
+    /// If not present creates directory with specified path
     #[throws]
     async fn create_directory(&self, path: &PathBuf) {
         match path.exists() {
@@ -391,8 +602,8 @@ impl TestGenerator {
             }
         };
     }
-    /// ##  Creates a new file with a given content on the specified path
-    /// - Skip if file already exists
+    /// If not present creates a new file with a given content on the specified path
+    /// If file is present, skip
     #[throws]
     async fn create_file(&self, path: &PathBuf, content: &str) {
         let file = path.strip_prefix(&self.root).unwrap().to_str().unwrap();
@@ -403,28 +614,43 @@ impl TestGenerator {
             }
             false => {
                 fs::write(path, content).await?;
-                println!("\x1b[92mSuccesfully\x1b[0m created: {file}.");
+                println!("\x1b[92mSuccessfully\x1b[0m created: {file}.");
             }
         };
     }
-    /// ## Updates a file with a given content on the specified path
-    /// - Skip if file does not exists
+    /// If present update a new file with a given content on the specified path
+    /// If file is not present, skip
     #[throws]
     async fn update_file(&self, path: &PathBuf, content: &str) {
         let file = path.strip_prefix(&self.root).unwrap().to_str().unwrap();
         match path.exists() {
             true => {
                 fs::write(path, content).await?;
-                println!("\x1b[92mSuccesfully\x1b[0m updated: {file}.");
+                println!("\x1b[92mSuccessfully\x1b[0m updated: {file}.");
             }
             false => {
                 fs::write(path, content).await?;
-                println!("\x1b[92mSuccesfully\x1b[0m created: {file}.");
+                println!("\x1b[92mSuccessfully\x1b[0m created: {file}.");
             }
         };
     }
 
-    /// ## Updates .gitignore file in the `root` directory and appends `ignored_path` to the end of the file
+    /// Updates the `.gitignore` file by appending a specified path to ignore.
+    ///
+    /// This function checks if the given `ignored_path` is already listed in the `.gitignore` file at the root
+    /// of the repository. If the path is not found, it appends the `ignored_path` to the file, ensuring that it
+    /// is ignored by Git. If the `.gitignore` file does not exist or the path is already included, the function
+    /// will skip the addition and print a message.
+    ///
+    /// # Parameters
+    /// - `&self`: A reference to the current instance of the TestGenerator that holds the repository root path.
+    /// - `ignored_path`: A string slice (`&str`) representing the path to be ignored by Git. This path should be
+    /// relative to the repository root.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - The `.gitignore` file exists but cannot be opened or read.
+    /// - There is an error writing the new `ignored_path` to the `.gitignore` file.
     #[throws]
     fn update_gitignore(&self, ignored_path: &str) {
         let gitignore_path = construct_path!(self.root, GIT_IGNORE);
@@ -447,12 +673,31 @@ impl TestGenerator {
 
             if let Ok(mut file) = file {
                 writeln!(file, "{}", ignored_path)?;
-                println!("\x1b[92mSuccesfully\x1b[0m updated: {GIT_IGNORE} with {ignored_path}.");
+                println!("\x1b[92mSuccessfully\x1b[0m updated: {GIT_IGNORE} with {ignored_path}.");
             }
         } else {
             println!("\x1b[93mSkipping\x1b[0m: {GIT_IGNORE}, not found.")
         }
     }
+    /// Adds a new binary target to a Cargo.toml file.
+    ///
+    /// This function reads the existing `Cargo.toml` file from the specified path, adds a new binary target
+    /// configuration to it, and writes the updated content back to the file. It handles the creation of a new
+    /// `[[bin]]` section if one does not already exist or appends the new binary target to the existing `[[bin]]`
+    /// array. The new binary target is specified by its name and the path to its source file.
+    ///
+    /// # Parameters
+    /// - `&self`: A reference to the current instance of the TestGenerator, not used directly in this function but
+    /// necessary for method calls on the instance.
+    /// - `cargo_path`: A reference to a `PathBuf` that specifies the path to the `Cargo.toml` file to be updated.
+    /// - `name`: A string slice (`&str`) representing the name of the binary target to be added.
+    /// - `path`: A string slice (`&str`) representing the path to the source file of the binary target, relative
+    /// to the Cargo package's root.
+    ///
+    /// # Errors
+    /// This function returns an error if:
+    /// - The `Cargo.toml` file cannot be read or written to.
+    /// - The content of `Cargo.toml` cannot be parsed into a `toml::Value` or manipulated as expected.
     #[throws]
     async fn add_bin_target(&self, cargo_path: &PathBuf, name: &str, path: &str) {
         // Read the existing Cargo.toml file
@@ -481,8 +726,28 @@ impl TestGenerator {
         // Write the updated Cargo.toml file
         fs::write(cargo_path, cargo_toml.to_string()).await?;
     }
-    /// ## Adds program dependency to specified Cargo.toml
-    /// - for example, we need to use program entry within the fuzzer
+    /// Adds program dependencies to a specified Cargo.toml file.
+    ///
+    /// This function updates the Cargo.toml file located in the given directory by adding new dependencies
+    /// specified by the `deps` parameter. It supports adding dependencies with or without features. The
+    /// dependencies are added based on the packages found in the `self.packages` collection of the TestGenerator,
+    /// where each package's path is adjusted to be relative to the specified `cargo_dir`. If no packages are
+    /// found in `self.packages`, the function will return an error.
+    ///
+    /// # Parameters
+    /// - `&self`: A reference to the current instance of the TestGenerator, which contains a collection of packages
+    /// to be added as dependencies.
+    /// - `cargo_dir`: A reference to a `PathBuf` indicating the directory where the `Cargo.toml` file to be updated is located.
+    /// - `deps`: A string slice (`&str`) specifying the section under which the dependencies should be added
+    /// (e.g., `dependencies`, `dev-dependencies`, etc.).
+    /// - `features`: An optional vector of string slices (`Vec<&str>`) specifying the features that should be
+    /// enabled for the dependencies being added. If `None`, no features are specified.
+    ///
+    /// # Errors
+    /// This function can return errors in several cases, including:
+    /// - If the specified `Cargo.toml` file cannot be read or written to.
+    /// - If parsing of the `Cargo.toml` file or the dependencies fails.
+    /// - If no packages are found in `self.packages`.
     #[throws]
     async fn add_program_dependencies(
         &self,
@@ -499,38 +764,37 @@ impl TestGenerator {
             .and_then(toml::Value::as_table_mut)
             .ok_or(Error::ParsingCargoTomlDependenciesFailed)?;
 
-        if !&self.packages.is_empty() {
-            for package in self.packages.iter() {
-                let manifest_path = package.manifest_path.parent().unwrap().as_std_path();
-                // INFO this will obtain relative path
-                let relative_path = pathdiff::diff_paths(manifest_path, cargo_dir).unwrap();
-                let dep: Value = if features.is_some() {
-                    format!(
-                        r#"{} = {{ path = "{}", features = {:?} }}"#,
-                        package.name,
-                        relative_path.to_str().unwrap(),
-                        features.as_ref().unwrap()
-                    )
-                    .parse()
-                    .unwrap()
-                } else {
-                    format!(
-                        r#"{} = {{ path = "{}" }}"#,
-                        package.name,
-                        relative_path.to_str().unwrap()
-                    )
-                    .parse()
-                    .unwrap()
-                };
-                if let toml::Value::Table(table) = dep {
-                    let (name, value) = table.into_iter().next().unwrap();
-                    client_toml_deps.entry(name).or_insert(value.clone());
-                }
-            }
-            fs::write(cargo_path, cargo_toml_content.to_string()).await?;
-        } else {
+        if self.packages.is_empty() {
             throw!(Error::NoProgramsFound)
         }
+        for package in self.packages.iter() {
+            let manifest_path = package.manifest_path.parent().unwrap().as_std_path();
+            // INFO this will obtain relative path
+            let relative_path = pathdiff::diff_paths(manifest_path, cargo_dir).unwrap();
+            let dep: Value = if features.is_some() {
+                format!(
+                    r#"{} = {{ path = "{}", features = {:?} }}"#,
+                    package.name,
+                    relative_path.to_str().unwrap(),
+                    features.as_ref().unwrap()
+                )
+                .parse()
+                .unwrap()
+            } else {
+                format!(
+                    r#"{} = {{ path = "{}" }}"#,
+                    package.name,
+                    relative_path.to_str().unwrap()
+                )
+                .parse()
+                .unwrap()
+            };
+            if let toml::Value::Table(table) = dep {
+                let (name, value) = table.into_iter().next().unwrap();
+                client_toml_deps.entry(name).or_insert(value.clone());
+            }
+        }
+        fs::write(cargo_path, cargo_toml_content.to_string()).await?;
     }
 }
 

--- a/crates/client/tests/test_fuzz.rs
+++ b/crates/client/tests/test_fuzz.rs
@@ -18,9 +18,10 @@ async fn test_fuzz_instructions() {
         "/tests/test_data/expected_source_codes/expected_fuzz_instructions.rs"
     ));
 
-    let program_idl =
-        trdelnik_client::idl::parse_to_idl_program(PROGRAM_NAME.to_owned(), expanded_fuzz_example3)
-            .await?;
+    let program_idl = trdelnik_client::idl::parse_to_idl_program(
+        PROGRAM_NAME.to_owned(),
+        expanded_fuzz_example3,
+    )?;
 
     let idl = trdelnik_client::idl::Idl {
         programs: vec![program_idl],

--- a/crates/client/tests/test_program_client.rs
+++ b/crates/client/tests/test_program_client.rs
@@ -21,7 +21,7 @@ pub async fn generate_program_client() {
     ));
 
     let program_idl =
-        trdelnik_client::idl::parse_to_idl_program("escrow".to_owned(), expanded_escrow).await?;
+        trdelnik_client::idl::parse_to_idl_program("escrow".to_owned(), expanded_escrow)?;
 
     let idl = trdelnik_client::idl::Idl {
         programs: vec![program_idl],

--- a/examples/escrow/Cargo.lock
+++ b/examples/escrow/Cargo.lock
@@ -2757,11 +2757,9 @@ name = "poc_tests"
 version = "0.1.0"
 dependencies = [
  "anchor-spl",
- "assert_matches",
  "escrow",
  "fehler",
  "program_client",
- "rstest 0.12.0",
  "trdelnik-client",
 ]
 
@@ -3174,19 +3172,6 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rstest"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d912f35156a3f99a66ee3e11ac2e0b3f34ac85a07e05263d05a7e2c8810d616f"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4910,9 +4895,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5200,13 +5185,14 @@ dependencies = [
  "fehler",
  "futures",
  "heck 0.4.1",
+ "indicatif",
  "lazy_static",
  "log",
  "pathdiff",
  "proc-macro2",
  "quote",
  "rand 0.8.5",
- "rstest 0.18.2",
+ "rstest",
  "serde",
  "serde_json",
  "serial_test",

--- a/examples/escrow/trdelnik-tests/poc_tests/Cargo.toml
+++ b/examples/escrow/trdelnik-tests/poc_tests/Cargo.toml
@@ -4,18 +4,15 @@ version = "0.1.0"
 description = "Created with Trdelnik"
 edition = "2021"
 
+[dev-dependencies]
+fehler = "1.0.0"
+anchor-spl = "0.29.0"
+
 [dev-dependencies.trdelnik-client]
 path = "../../../../crates/client"
 
 [dev-dependencies.program_client]
 path = "../../.program_client"
 
-[dependencies]
-assert_matches = "1.4.0"
-fehler = "1.0.0"
-rstest = "0.12.0"
-anchor-spl = "0.29.0"
-
-
-[dependencies.escrow]
+[dev-dependencies.escrow]
 path = "../../programs/escrow"

--- a/examples/turnstile/Cargo.lock
+++ b/examples/turnstile/Cargo.lock
@@ -2754,10 +2754,8 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 name = "poc_tests"
 version = "0.1.0"
 dependencies = [
- "assert_matches",
  "fehler",
  "program_client",
- "rstest 0.12.0",
  "trdelnik-client",
  "turnstile",
 ]
@@ -3180,19 +3178,6 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rstest"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d912f35156a3f99a66ee3e11ac2e0b3f34ac85a07e05263d05a7e2c8810d616f"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4916,9 +4901,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5217,13 +5202,14 @@ dependencies = [
  "fehler",
  "futures",
  "heck 0.4.1",
+ "indicatif",
  "lazy_static",
  "log",
  "pathdiff",
  "proc-macro2",
  "quote",
  "rand 0.8.5",
- "rstest 0.18.2",
+ "rstest",
  "serde",
  "serde_json",
  "serial_test",

--- a/examples/turnstile/trdelnik-tests/poc_tests/Cargo.toml
+++ b/examples/turnstile/trdelnik-tests/poc_tests/Cargo.toml
@@ -3,16 +3,15 @@ name = "poc_tests"
 version = "0.1.0"
 description = "Created with Trdelnik"
 edition = "2021"
+
+[dev-dependencies]
+fehler = "1.0.0"
+
 [dev-dependencies.trdelnik-client]
 path = "../../../../crates/client"
 
 [dev-dependencies.program_client]
 path = "../../.program_client"
 
-[dependencies]
-assert_matches = "1.4.0"
-fehler = "1.0.0"
-rstest = "0.12.0"
-
-[dependencies.turnstile]
+[dev-dependencies.turnstile]
 path = "../../programs/turnstile"


### PR DESCRIPTION
Currently, the user experience during the initialization process is not the best. For example, during rustc +nightly nothing is shown within the console so it looks like nothing is happening, or it is possible to call trdelnik init on an already initialized workspace. This PR contains a lot of changes that I was trying to avoid, however, there were some unnecessary functions and logic which I think I (hopefully) successfully simplified.

Init command:
- Build - after internal discussion I agree that this command is necessary, as If the project cannot be built It can result in incorrectly generated test files. However as we only support anchor-type projects, instead of calling cargo build-sbf, this is changed to anchor build (we only support anchor-type projects)
- Programs Expansion - The program Expansion function within the Commander was modified to include also very simple progress bar that indicates that something is happening.
In terms of time, I still think that the rustc +nightly eats most of the time because:
I tried to benchmark the parse_to_idl_program function which resulted in approximately 25 ms
Moreover for example fuzz add performs also rustc +nightly with parse_to_idl_program, and this command is almost instant on the already initialized workspace.
- Folders initialization
Both and PoC test types - check if the program_client folder structure already exists, if so we expect that the program_client is already initialized = skip initializing program client. Check if PoC folder structure already exists if so skip initializing PoC Tests. For Fuzz Tests logic is the same
Fuzz test types - this test type is now generated without using program_client. We check if the fuzz_tests folder structure is present if so - skip.
- Trdelnik.toml and Updating gitignore
This is the last step

Build Command
- Checks if Trdelnik.toml is present if so, generate/update program_client. If POC tests are not present (only fuzz tests are present) this will still generate program_client as I found it useful to let the user generate this crate if they want.

Test Command for PoC Tests:
- This command calls the build command and then test

Fuzz Add 
- Calls the build command so fuzz test files are correctly generated

Other commands are unchanged

Then there are small changes
I updated templates
I moved most of the constants into one private mod
The snake case program name is in snake case
   
 

TODO: add into supported version that SOLANA CLI 1.18 is required to use trdelnik init 