### PR TITLE
fix/Fixed fuzz test generation with init-if-needed Anchor feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["crates/cli", "crates/client", "crates/explorer", "crates/test"]
 exclude = ["examples/"]
+resolver = "1"
 
 
 [workspace.dependencies]
@@ -20,19 +21,10 @@ solana-vote-program             = "<1.18"
 spl-token                       = "4.0.0"
 spl-memo                        = "4.0.0"
 spl-associated-token-account    = "2.0.0"
-tokio                           = { version = "1",features = [
-                                    "rt-multi-thread",
-                                    "macros",
-                                    "fs",
-                                    "signal",
-                                    "sync",
-                                    "time",
-                                    "io-util",
-                                    "process",
-                                    ], default-features = false}
+tokio                           = { version = "1", default-features = false }
 rand                            = "0.8.5"
 serde_json                      = "1.0.72"
-serde                           = "1.0.136"
+serde                           = { version = "1.0.136", default-features = false }
 bincode                         = "1.3.3"
 borsh                           = "0.10.3"
 futures                         = "0.3.18"
@@ -42,7 +34,7 @@ ed25519-dalek                   = "1.0.1"
 serial_test                     = "2.0.0"
 anyhow                          = { version = "1.0.45", features = ["std"], default-features = false }
 cargo_metadata                  = "0.17.0"
-syn                             = { version = "1.0.109", features = ["full"] }
+syn                             = { version = "1.0.109", default-features = false }
 quote                           = "1.0.14"
 heck                            = { version = "0.4.0", default-features = false }
 toml                            = { version = "0.5.8", features = ["preserve_order"] }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -31,7 +31,7 @@ trdelnik-test = { workspace = true }
 # INFO: This is a hack! Anchor-spl is here as dependency only to activate the idl-build feature, so that
 # users do not have to do it manually in their program's Cargo.toml
 anchor-spl = { version = "0.29.0", features = ["idl-build"] }
-anchor-lang = { version = "0.29.0", features = ["idl-build"] }
+anchor-lang = { version = "0.29.0", features = ["idl-build", "init-if-needed"] }
 solana-sdk = { workspace = true }
 solana-cli-output = { workspace = true }
 solana-transaction-status = { workspace = true }
@@ -52,7 +52,7 @@ ed25519-dalek = { workspace = true }
 serial_test = { workspace = true }
 anyhow = { workspace = true }
 cargo_metadata = { workspace = true }
-syn = { workspace = true }
+syn = { workspace = true, features = ["visit"] }
 quote = { workspace = true }
 heck = { workspace = true }
 toml = { workspace = true }


### PR DESCRIPTION
When using `init-if-needed` Anchor feature, the fuzz test generation failed, because we are using Anchor's parsing method to parse the context structs where also the Anchor constraints are parsed and it is verified, that the `init-if-needed` feature is activated properly. However Trdelnik did not activate this feature and the verification during parsing failed. 

Also this PR resolves the `warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"``. The resolver is now explicitly set to 1, because it merges the activated features for the whole workspace which is required for the `init-if-needed` feature to be propagated. Note that this warning may still be present due to Anchor settings, but this cannot be influenced by Trdelnik.