### PR TITLE
fix/warn user on composite accounts and continue fuzz test generation

### DIFF
--- a/Fuzzing.md
+++ b/Fuzzing.md
@@ -205,6 +205,7 @@ This section summarizes some known limitations in the current development stage.
 
 - Only fuzzing of one program without CPIs to other custom programs is supported.
 - Remaining accounts in check methods are not supported.
+- Composite accounts are not supported (however it is possible to generate a fuzz test and finish the composite accounts deserialization manually).
 
 ## Fuzz test examples
 - [Fuzz test example 0](examples/fuzz_example0)


### PR DESCRIPTION
With this PR, the user gets notified in case the anchor program uses currently unsupported composite accounts. Now the fuzz test generation is not aborted but continues and the composite account deserialization code is replaced with a `todo!()` macro.

A warning example:
```console
Warning: The context `Initialize` has a field named `comp_acc` of composite type `LiqPoolInitialize < 'info >`. The automatic deserialization of composite types is currently not supported. You will have to implement it manually in the generated `accounts_snapshots.rs` file. The field deserialization was replaced by a `todo!()` macro. Also, you might want to adapt the corresponding FuzzInstruction variants in `fuzz_instructions.rs` file.
```