### PR TITLE
Extend use statements and Data Accounts paths for fuzz snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ incremented upon a breaking change and the patch version will be incremented for
 
 ## [Unreleased]
 ### Added
+- feat/support of automatically obtaining fully qualified paths of Data Accounts Custom types for `accounts_snapshots.rs` ([#141](https://github.com/Ackee-Blockchain/trdelnik/pull/141))
 - feat/allow direct accounts manipulation and storage ([#142](https://github.com/Ackee-Blockchain/trdelnik/pull/142))
 - feat/support of non-corresponding instruction and context names ([#130](https://github.com/Ackee-Blockchain/trdelnik/pull/130))
 - feat/refactored and improved program flow during init and build, added activity indicator ([#129](https://github.com/Ackee-Blockchain/trdelnik/pull/129))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6013,6 +6013,7 @@ dependencies = [
  "quinn-proto",
  "quote",
  "rand 0.8.5",
+ "regex",
  "rstest",
  "serde",
  "serde_json",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -70,3 +70,4 @@ shellexpand = { workspace = true }
 pathdiff = "0.2.1"
 solana-banks-client = "<1.18"
 indicatif = "0.17.8"
+regex = "1.10.3"

--- a/crates/client/src/cleaner.rs
+++ b/crates/client/src/cleaner.rs
@@ -54,7 +54,7 @@ impl Cleaner {
             fs::remove_dir_all(hfuzz_target_path).await?;
         } else {
             println!(
-                "skipping {}/{}/{}/{} directory: not found",
+                "{SKIP} [{}/{}/{}/{}] directory not found",
                 TESTS_WORKSPACE_DIRECTORY, FUZZ_TEST_DIRECTORY, FUZZING, HFUZZ_TARGET
             )
         }

--- a/crates/client/src/fuzzer/fuzzer_generator.rs
+++ b/crates/client/src/fuzzer/fuzzer_generator.rs
@@ -1,16 +1,16 @@
 use std::collections::HashMap;
 
-use crate::idl::Idl;
+use crate::idl::IdlProgram;
+use cargo_metadata::camino::Utf8PathBuf;
 use proc_macro2::Ident;
 use quote::{format_ident, ToTokens};
 use syn::{parse_quote, parse_str};
 
 /// Generates `fuzz_instructions.rs` from [Idl] created from Anchor programs.
-pub fn generate_source_code(idl: &Idl) -> String {
-    let code = idl
-        .programs
+pub fn generate_source_code(code_path: &[(String, Utf8PathBuf, IdlProgram)]) -> String {
+    let code = code_path
         .iter()
-        .map(|idl_program| {
+        .map(|(_, _, idl_program)| {
             let program_name = &idl_program.name.snake_case;
             let fuzz_instructions_module_name = format_ident!("{}_fuzz_instructions", program_name);
             let module_name: syn::Ident = parse_str(program_name).unwrap();

--- a/crates/client/src/fuzzer/snapshot_generator.rs
+++ b/crates/client/src/fuzzer/snapshot_generator.rs
@@ -282,12 +282,12 @@ fn create_snapshot_struct(
                                 Ok(quote! {pub #field_name: Option<&'info #field_type>,})
                             }
                             (true, _) => {
-                                let field_type = construct_full_path(&field_type.to_token_stream(),parsed_file,program_name).unwrap_or(field_type.clone());
+                                let field_type = construct_full_path(&field_type.to_token_stream(), parsed_file, program_name).unwrap_or_else(|| field_type.clone());
                                 Ok(quote! {pub #field_name: Option<#field_type>,})
                             },
                             (_, true) => Ok(quote! {pub #field_name: &'info #field_type,}),
                             _ => {
-                                let field_type = construct_full_path(&field_type.to_token_stream(),parsed_file,program_name).unwrap_or(field_type.clone());
+                                let field_type = construct_full_path(&field_type.to_token_stream(), parsed_file, program_name).unwrap_or_else(|| field_type.clone());
                                 Ok(quote! {pub #field_name: #field_type,})
                             },
                         }

--- a/crates/client/src/fuzzer/snapshot_generator.rs
+++ b/crates/client/src/fuzzer/snapshot_generator.rs
@@ -56,10 +56,12 @@ pub fn generate_snapshots_code(programs_data: &[ProgramData]) -> Result<String, 
             &program_data.program_idl.name.snake_case,
         )?;
 
+        let program_name_ident = format_ident!("{}", program_data.program_idl.name.snake_case);
+
         let use_statements = quote! {
             use trdelnik_client::anchor_lang::{prelude::*, self};
             use trdelnik_client::fuzzing::FuzzingError;
-            use crate::PROGRAM_ID;
+            use #program_name_ident::ID as PROGRAM_ID;
         }
         .into_token_stream();
         Ok(format!(

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -136,4 +136,13 @@ mod constants {
     // client
     pub const RETRY_LOCALNET_EVERY_MILLIS: u64 = 500;
     pub const DEFAULT_KEYPAIR_PATH: &str = "~/.config/solana/id.json";
+
+    // Formatting
+    pub const SKIP: &str = "\x1b[33mSkip\x1b[0m";
+    pub const WARNING: &str = "\x1b[1;93mWarning\x1b[0m";
+    pub const FINISH: &str = "\x1b[92mFinished\x1b[0m";
+    pub const ERROR: &str = "\x1b[31mError\x1b[0m";
+
+    // special message for the progress bar
+    pub const EXPANDING_PROGRESS_BAR: &str = "\x1b[92mExpanding\x1b[0m";
 }

--- a/crates/client/src/program_client_generator.rs
+++ b/crates/client/src/program_client_generator.rs
@@ -1,4 +1,5 @@
-use crate::idl::Idl;
+use crate::idl::IdlProgram;
+use cargo_metadata::camino::Utf8PathBuf;
 use quote::{format_ident, ToTokens};
 use syn::{parse_quote, parse_str};
 
@@ -6,12 +7,15 @@ use syn::{parse_quote, parse_str};
 /// Disable regenerating the `use` statements with a used imports `use_modules`
 ///
 /// _Note_: See the crate's tests for output example.
-pub fn generate_source_code(idl: &Idl, use_modules: &[syn::ItemUse]) -> String {
+pub fn generate_source_code(
+    code_path: &[(String, Utf8PathBuf, IdlProgram)],
+    use_modules: &[syn::ItemUse],
+) -> String {
     let mut output = "// DO NOT EDIT - automatically generated file (except `use` statements inside the `*_instruction` module\n".to_owned();
-    let code = idl
-        .programs
+    // let code = code_path.into_iter().map(|(_, _, idl_program)| {});
+    let code = code_path
         .iter()
-        .map(|idl_program| {
+        .map(|(_, _, idl_program)| {
             let program_name = &idl_program.name.snake_case;
             let instruction_module_name = format_ident!("{}_instruction", program_name);
             let module_name: syn::Ident = parse_str(program_name).unwrap();

--- a/crates/client/src/program_client_generator.rs
+++ b/crates/client/src/program_client_generator.rs
@@ -1,5 +1,4 @@
-use crate::idl::IdlProgram;
-use cargo_metadata::camino::Utf8PathBuf;
+use crate::test_generator::ProgramData;
 use quote::{format_ident, ToTokens};
 use syn::{parse_quote, parse_str};
 
@@ -7,21 +6,19 @@ use syn::{parse_quote, parse_str};
 /// Disable regenerating the `use` statements with a used imports `use_modules`
 ///
 /// _Note_: See the crate's tests for output example.
-pub fn generate_source_code(
-    code_path: &[(String, Utf8PathBuf, IdlProgram)],
-    use_modules: &[syn::ItemUse],
-) -> String {
+pub fn generate_source_code(programs_data: &[ProgramData], use_modules: &[syn::ItemUse]) -> String {
     let mut output = "// DO NOT EDIT - automatically generated file (except `use` statements inside the `*_instruction` module\n".to_owned();
     // let code = code_path.into_iter().map(|(_, _, idl_program)| {});
-    let code = code_path
+    let code = programs_data
         .iter()
-        .map(|(_, _, idl_program)| {
-            let program_name = &idl_program.name.snake_case;
+        .map(|program_data| {
+            let program_name = &program_data.program_idl.name.snake_case;
             let instruction_module_name = format_ident!("{}_instruction", program_name);
             let module_name: syn::Ident = parse_str(program_name).unwrap();
-            let pubkey_bytes: syn::ExprArray = parse_str(&idl_program.id).unwrap();
+            let pubkey_bytes: syn::ExprArray = parse_str(&program_data.program_idl.id).unwrap();
 
-            let instructions = idl_program
+            let instructions = program_data
+                .program_idl
                 .instruction_account_pairs
                 .iter()
                 .fold(

--- a/crates/client/src/test_generator.rs
+++ b/crates/client/src/test_generator.rs
@@ -91,6 +91,13 @@ macro_rules! load_template {
     };
 }
 
+#[derive(Clone)]
+pub struct ProgramData {
+    pub code: String,
+    pub path: Utf8PathBuf,
+    pub program_idl: IdlProgram,
+}
+
 /// Represents a generator for creating tests.
 ///
 /// This struct is designed to hold all necessary information for generating
@@ -108,7 +115,7 @@ macro_rules! load_template {
 /// should be included in the generated code for .program_client.
 pub struct TestGenerator {
     pub root: PathBuf,
-    pub programs_data: Vec<(String, Utf8PathBuf, IdlProgram)>,
+    pub programs_data: Vec<ProgramData>,
     pub packages: Vec<Package>,
     pub use_tokens: Vec<ItemUse>,
 }
@@ -361,7 +368,13 @@ impl TestGenerator {
     #[throws]
     async fn add_new_poc_test(&self) {
         let program_name = if !&self.programs_data.is_empty() {
-            &self.programs_data.first().unwrap().2.name.snake_case
+            &self
+                .programs_data
+                .first()
+                .unwrap()
+                .program_idl
+                .name
+                .snake_case
         } else {
             throw!(Error::NoProgramsFound)
         };
@@ -405,7 +418,13 @@ impl TestGenerator {
     #[throws]
     pub async fn add_new_fuzz_test(&self) {
         let program_name = if !&self.programs_data.is_empty() {
-            &self.programs_data.first().unwrap().2.name.snake_case
+            &self
+                .programs_data
+                .first()
+                .unwrap()
+                .program_idl
+                .name
+                .snake_case
         } else {
             throw!(Error::NoProgramsFound)
         };

--- a/crates/client/src/test_generator.rs
+++ b/crates/client/src/test_generator.rs
@@ -1,7 +1,7 @@
 use crate::{
     commander::{Commander, Error as CommanderError},
     fuzzer,
-    idl::Idl,
+    idl::IdlProgram,
     program_client_generator,
     snapshot_generator::generate_snapshots_code,
 };
@@ -100,9 +100,7 @@ macro_rules! load_template {
 /// # Fields
 /// - `root`: A `PathBuf` indicating the root directory of the project for which tests are being generated.
 /// This path is used as a base for any relative paths within the project.
-/// - `idl`: An `Idl` struct. This field is used to understand the interfaces
-/// and data structures that tests may need to interact with.
-/// - `codes_libs_pairs`: A vector of tuples, each containing a `String` and a `Utf8PathBuf`.
+/// - `programs_data`: A vector of tuples, each containing a `String`, `Utf8PathBuf` and IDL Program data.
 /// Each tuple represents a pair of code and the package path associated with it.
 /// - `packages`: A vector of `Package` structs, representing the different packages
 /// that make up the project.
@@ -110,8 +108,7 @@ macro_rules! load_template {
 /// should be included in the generated code for .program_client.
 pub struct TestGenerator {
     pub root: PathBuf,
-    pub idl: Idl,
-    pub codes_libs_pairs: Vec<(String, Utf8PathBuf)>,
+    pub programs_data: Vec<(String, Utf8PathBuf, IdlProgram)>,
     pub packages: Vec<Package>,
     pub use_tokens: Vec<ItemUse>,
 }
@@ -130,8 +127,7 @@ impl TestGenerator {
     pub fn new() -> Self {
         Self {
             root: Path::new("../../").to_path_buf(),
-            idl: Idl::default(),
-            codes_libs_pairs: Vec::default(),
+            programs_data: Vec::default(),
             packages: Vec::default(),
             use_tokens: Vec::default(),
         }
@@ -148,8 +144,7 @@ impl TestGenerator {
     pub fn new_with_root(root: String) -> Self {
         Self {
             root: Path::new(&root).to_path_buf(),
-            idl: Idl::default(),
-            codes_libs_pairs: Vec::default(),
+            programs_data: Vec::default(),
             packages: Vec::default(),
             use_tokens: Vec::default(),
         }
@@ -260,8 +255,7 @@ impl TestGenerator {
     #[throws]
     async fn expand_programs(&mut self) {
         self.packages = Commander::collect_program_packages().await?;
-        (self.idl, self.codes_libs_pairs) =
-            Commander::expand_program_packages(&self.packages).await?;
+        self.programs_data = Commander::expand_program_packages(&self.packages).await?;
     }
     /// Get user specified use statements from .program_client lib.
     #[throws]
@@ -269,7 +263,9 @@ impl TestGenerator {
         let lib_path = construct_path!(self.root, PROGRAM_CLIENT_DIRECTORY, SRC_DIRECTORY, LIB);
         if lib_path.exists() {
             let code = fs::read_to_string(lib_path).await.unwrap_or_else(|_e| {
-                println!("\x1b[1;93mWarning\x1b[0m: Unable to read .program_client, use statements set to default.");
+                println!(
+                    "{WARNING} Unable to read [.program_client], use statements set to default"
+                );
                 String::default()
             });
             Commander::get_use_statements(&code, &mut self.use_tokens)?;
@@ -290,7 +286,7 @@ impl TestGenerator {
         let lib_path = construct_path!(self.root, PROGRAM_CLIENT_DIRECTORY, SRC_DIRECTORY, LIB);
 
         if cargo_path.exists() && src_path.exists() && crate_path.exists() && lib_path.exists() {
-            println!("\x1b[93mSkipping\x1b[0m: looks like .program_client is already initialized.");
+            println!("{SKIP} looks like [.program_client] is already initialized");
         } else {
             self.add_program_client().await?;
         }
@@ -322,7 +318,7 @@ impl TestGenerator {
             directories.retain(|x| x != CARGO_TOML);
             // if folder structure exists and fuzz_tests directory is not empty we skip
             if fuzz_tests_manifest_path.exists() && !directories.is_empty() {
-                println!("\x1b[93mSkipping\x1b[0m: looks like Fuzz Tests are already initialized.");
+                println!("{SKIP} looks like [Fuzz] Tests are already initialized");
             } else {
                 self.add_new_fuzz_test().await?
             }
@@ -349,7 +345,7 @@ impl TestGenerator {
             && cargo_path.exists()
             && poc_test_path.exists()
         {
-            println!("\x1b[93mSkipping\x1b[0m: looks like PoC Tests are already initialized.");
+            println!("{SKIP} looks like [PoC] Tests are already initialized");
         } else {
             self.add_new_poc_test().await?;
         }
@@ -364,12 +360,11 @@ impl TestGenerator {
     /// If not present add poc_tests into the workspace virtual manifest as member
     #[throws]
     async fn add_new_poc_test(&self) {
-        let program_name = if !&self.idl.programs.is_empty() {
-            &self.idl.programs.first().unwrap().name.snake_case
+        let program_name = if !&self.programs_data.is_empty() {
+            &self.programs_data.first().unwrap().2.name.snake_case
         } else {
             throw!(Error::NoProgramsFound)
         };
-
         let poc_dir_path =
             construct_path!(self.root, TESTS_WORKSPACE_DIRECTORY, POC_TEST_DIRECTORY);
         let new_poc_test_dir = construct_path!(poc_dir_path, TESTS_DIRECTORY);
@@ -409,8 +404,8 @@ impl TestGenerator {
     /// If not present add fuzz_tests into the workspace virtual manifest as member
     #[throws]
     pub async fn add_new_fuzz_test(&self) {
-        let program_name = if !&self.idl.programs.is_empty() {
-            &self.idl.programs.first().unwrap().name.snake_case
+        let program_name = if !&self.programs_data.is_empty() {
+            &self.programs_data.first().unwrap().2.name.snake_case
         } else {
             throw!(Error::NoProgramsFound)
         };
@@ -475,7 +470,7 @@ impl TestGenerator {
 
         // create fuzz instructions file
         let fuzz_instructions_path = new_fuzz_test_dir.join(FUZZ_INSTRUCTIONS_FILE_NAME);
-        let program_fuzzer = fuzzer::fuzzer_generator::generate_source_code(&self.idl);
+        let program_fuzzer = fuzzer::fuzzer_generator::generate_source_code(&self.programs_data);
         let program_fuzzer = Commander::format_program_code(&program_fuzzer).await?;
 
         self.create_file(&fuzz_instructions_path, &program_fuzzer)
@@ -483,8 +478,8 @@ impl TestGenerator {
 
         // // create accounts_snapshots file
         let accounts_snapshots_path = new_fuzz_test_dir.join(ACCOUNTS_SNAPSHOTS_FILE_NAME);
-        let fuzzer_snapshots = generate_snapshots_code(&self.codes_libs_pairs)
-            .map_err(Error::ReadProgramCodeFailed)?;
+        let fuzzer_snapshots =
+            generate_snapshots_code(&self.programs_data).map_err(Error::ReadProgramCodeFailed)?;
         let fuzzer_snapshots = Commander::format_program_code(&fuzzer_snapshots).await?;
 
         self.create_file(&accounts_snapshots_path, &fuzzer_snapshots)
@@ -534,7 +529,7 @@ impl TestGenerator {
             .await?;
 
         let program_client =
-            program_client_generator::generate_source_code(&self.idl, &self.use_tokens);
+            program_client_generator::generate_source_code(&self.programs_data, &self.use_tokens);
         let program_client = Commander::format_program_code(&program_client).await?;
 
         if lib_path.exists() {
@@ -592,11 +587,11 @@ impl TestGenerator {
 
         match members.iter().find(|&x| x.eq(&new_member)) {
             Some(_) => {
-                println!("\x1b[93mSkipping\x1b[0m: {CARGO_TOML}, already contains {member}.")
+                println!("{SKIP} [{CARGO_TOML}], already contains [{member}]")
             }
             None => {
                 members.push(new_member);
-                println!("\x1b[92mSuccessfully\x1b[0m updated: {CARGO_TOML} with {member} member.");
+                println!("{FINISH} [{CARGO_TOML}] with [{member}]");
                 fs::write(cargo, content.to_string()).await?;
             }
         };
@@ -631,11 +626,11 @@ impl TestGenerator {
 
         match path.exists() {
             true => {
-                println!("\x1b[93mSkipping\x1b[0m: {file}, already exists.")
+                println!("{SKIP} [{file}] already exists")
             }
             false => {
                 fs::write(path, content).await?;
-                println!("\x1b[92mSuccessfully\x1b[0m created: {file}.");
+                println!("{FINISH} [{file}] created");
             }
         };
     }
@@ -647,11 +642,11 @@ impl TestGenerator {
         match path.exists() {
             true => {
                 fs::write(path, content).await?;
-                println!("\x1b[92mSuccessfully\x1b[0m updated: {file}.");
+                println!("{FINISH} [{file}] updated");
             }
             false => {
                 fs::write(path, content).await?;
-                println!("\x1b[92mSuccessfully\x1b[0m created: {file}.");
+                println!("{FINISH} [{file}] created");
             }
         };
     }
@@ -680,9 +675,7 @@ impl TestGenerator {
             for line in io::BufReader::new(file).lines().flatten() {
                 if line == ignored_path {
                     // INFO do not add the ignored path again if it is already in the .gitignore file
-                    println!(
-                        "\x1b[93mSkipping\x1b[0m: {GIT_IGNORE}, already contains {ignored_path}."
-                    );
+                    println!("{SKIP} [{GIT_IGNORE}], already contains [{ignored_path}]");
 
                     return;
                 }
@@ -694,10 +687,10 @@ impl TestGenerator {
 
             if let Ok(mut file) = file {
                 writeln!(file, "{}", ignored_path)?;
-                println!("\x1b[92mSuccessfully\x1b[0m updated: {GIT_IGNORE} with {ignored_path}.");
+                println!("{FINISH} [{GIT_IGNORE}] update with [{ignored_path}]");
             }
         } else {
-            println!("\x1b[93mSkipping\x1b[0m: {GIT_IGNORE}, not found.")
+            println!("{SKIP} [{GIT_IGNORE}], not found")
         }
     }
     /// Adds a new binary target to a Cargo.toml file.

--- a/crates/client/tests/test_data/expected_source_codes/expected_accounts_snapshots.rs
+++ b/crates/client/tests/test_data/expected_source_codes/expected_accounts_snapshots.rs
@@ -1,4 +1,4 @@
-use crate::PROGRAM_ID;
+use fuzz_example3::ID as PROGRAM_ID;
 use trdelnik_client::anchor_lang::{self, prelude::*};
 use trdelnik_client::fuzzing::FuzzingError;
 pub struct InitVestingSnapshot<'info> {

--- a/crates/client/tests/test_data/expected_source_codes/expected_accounts_snapshots.rs
+++ b/crates/client/tests/test_data/expected_source_codes/expected_accounts_snapshots.rs
@@ -1,9 +1,10 @@
+use crate::PROGRAM_ID;
 use trdelnik_client::anchor_lang::{self, prelude::*};
 use trdelnik_client::fuzzing::FuzzingError;
 pub struct InitVestingSnapshot<'info> {
     pub sender: Signer<'info>,
     pub sender_token_account: Account<'info, TokenAccount>,
-    pub escrow: Option<Account<'info, Escrow>>,
+    pub escrow: Option<Account<'info, fuzz_example3::state::Escrow>>,
     pub escrow_token_account: Account<'info, TokenAccount>,
     pub mint: Account<'info, Mint>,
     pub token_program: Program<'info, Token>,
@@ -12,7 +13,7 @@ pub struct InitVestingSnapshot<'info> {
 pub struct WithdrawUnlockedSnapshot<'info> {
     pub recipient: Signer<'info>,
     pub recipient_token_account: Account<'info, TokenAccount>,
-    pub escrow: Option<Account<'info, Escrow>>,
+    pub escrow: Option<Account<'info, fuzz_example3::state::Escrow>>,
     pub escrow_token_account: Account<'info, TokenAccount>,
     pub escrow_pda_authority: &'info AccountInfo<'info>,
     pub mint: Account<'info, Mint>,
@@ -45,22 +46,24 @@ impl<'info> InitVestingSnapshot<'info> {
                 .map_err(|_| {
                     FuzzingError::CannotDeserializeAccount("sender_token_account".to_string())
                 })?;
-        let escrow: Option<anchor_lang::accounts::account::Account<Escrow>> = accounts_iter
-            .next()
-            .ok_or(FuzzingError::NotEnoughAccounts("escrow".to_string()))?
-            .as_ref()
-            .map(|acc| {
-                if acc.key() != PROGRAM_ID {
-                    anchor_lang::accounts::account::Account::try_from(acc)
-                        .map_err(|_| FuzzingError::CannotDeserializeAccount("escrow".to_string()))
-                } else {
-                    Err(FuzzingError::OptionalAccountNotProvided(
-                        "escrow".to_string(),
-                    ))
-                }
-            })
-            .transpose()
-            .unwrap_or(None);
+        let escrow: Option<anchor_lang::accounts::account::Account<fuzz_example3::state::Escrow>> =
+            accounts_iter
+                .next()
+                .ok_or(FuzzingError::NotEnoughAccounts("escrow".to_string()))?
+                .as_ref()
+                .map(|acc| {
+                    if acc.key() != PROGRAM_ID {
+                        anchor_lang::accounts::account::Account::try_from(acc).map_err(|_| {
+                            FuzzingError::CannotDeserializeAccount("escrow".to_string())
+                        })
+                    } else {
+                        Err(FuzzingError::OptionalAccountNotProvided(
+                            "escrow".to_string(),
+                        ))
+                    }
+                })
+                .transpose()
+                .unwrap_or(None);
         let escrow_token_account: anchor_lang::accounts::account::Account<TokenAccount> =
             accounts_iter
                 .next()
@@ -135,22 +138,24 @@ impl<'info> WithdrawUnlockedSnapshot<'info> {
                 .map_err(|_| {
                     FuzzingError::CannotDeserializeAccount("recipient_token_account".to_string())
                 })?;
-        let escrow: Option<anchor_lang::accounts::account::Account<Escrow>> = accounts_iter
-            .next()
-            .ok_or(FuzzingError::NotEnoughAccounts("escrow".to_string()))?
-            .as_ref()
-            .map(|acc| {
-                if acc.key() != PROGRAM_ID {
-                    anchor_lang::accounts::account::Account::try_from(acc)
-                        .map_err(|_| FuzzingError::CannotDeserializeAccount("escrow".to_string()))
-                } else {
-                    Err(FuzzingError::OptionalAccountNotProvided(
-                        "escrow".to_string(),
-                    ))
-                }
-            })
-            .transpose()
-            .unwrap_or(None);
+        let escrow: Option<anchor_lang::accounts::account::Account<fuzz_example3::state::Escrow>> =
+            accounts_iter
+                .next()
+                .ok_or(FuzzingError::NotEnoughAccounts("escrow".to_string()))?
+                .as_ref()
+                .map(|acc| {
+                    if acc.key() != PROGRAM_ID {
+                        anchor_lang::accounts::account::Account::try_from(acc).map_err(|_| {
+                            FuzzingError::CannotDeserializeAccount("escrow".to_string())
+                        })
+                    } else {
+                        Err(FuzzingError::OptionalAccountNotProvided(
+                            "escrow".to_string(),
+                        ))
+                    }
+                })
+                .transpose()
+                .unwrap_or(None);
         let escrow_token_account: anchor_lang::accounts::account::Account<TokenAccount> =
             accounts_iter
                 .next()

--- a/crates/client/tests/test_fuzz.rs
+++ b/crates/client/tests/test_fuzz.rs
@@ -2,6 +2,7 @@ use anyhow::Error;
 use cargo_metadata::camino::Utf8PathBuf;
 use fehler::throws;
 use pretty_assertions::assert_str_eq;
+use trdelnik_client::test_generator::ProgramData;
 
 const PROGRAM_NAME: &str = "fuzz_example3";
 
@@ -37,7 +38,15 @@ async fn test_snapshots_and_instructions() {
         expanded_fuzz_example3,
     )?;
 
-    let program_data = vec![(expanded_fuzz_example3.to_string(), path, program_idl)];
+    let code = expanded_fuzz_example3.to_string();
+
+    let program_data = ProgramData {
+        code,
+        path,
+        program_idl,
+    };
+
+    let program_data = vec![program_data];
 
     let fuzzer_snapshots =
         trdelnik_client::snapshot_generator::generate_snapshots_code(&program_data).unwrap();

--- a/crates/client/tests/test_fuzz.rs
+++ b/crates/client/tests/test_fuzz.rs
@@ -7,36 +7,7 @@ const PROGRAM_NAME: &str = "fuzz_example3";
 
 #[throws]
 #[tokio::test]
-async fn test_fuzz_instructions() {
-    let expanded_fuzz_example3 = include_str!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/tests/test_data/expanded_source_codes/expanded_fuzz_example3.rs"
-    ));
-
-    let expected_fuzz_instructions_code = include_str!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/tests/test_data/expected_source_codes/expected_fuzz_instructions.rs"
-    ));
-
-    let program_idl = trdelnik_client::idl::parse_to_idl_program(
-        PROGRAM_NAME.to_owned(),
-        expanded_fuzz_example3,
-    )?;
-
-    let idl = trdelnik_client::idl::Idl {
-        programs: vec![program_idl],
-    };
-
-    let fuzz_instructions_code = trdelnik_client::fuzzer_generator::generate_source_code(&idl);
-    let fuzz_instructions_code =
-        trdelnik_client::Commander::format_program_code(&fuzz_instructions_code).await?;
-
-    assert_str_eq!(fuzz_instructions_code, expected_fuzz_instructions_code);
-}
-
-#[throws]
-#[tokio::test]
-async fn test_account_snapshots() {
+async fn test_snapshots_and_instructions() {
     let expanded_fuzz_example3 = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/tests/test_data/expanded_source_codes/expanded_fuzz_example3.rs"
@@ -45,6 +16,10 @@ async fn test_account_snapshots() {
     let expected_accounts_snapshots = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/tests/test_data/expected_source_codes/expected_accounts_snapshots.rs"
+    ));
+    let expected_fuzz_instructions_code = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/test_data/expected_source_codes/expected_fuzz_instructions.rs"
     ));
 
     let mut program_path = std::env::current_dir()
@@ -57,14 +32,25 @@ async fn test_account_snapshots() {
 
     let path = Utf8PathBuf::from(program_path);
 
-    let codes_libs_pairs = vec![(expanded_fuzz_example3.to_string(), path)];
+    let program_idl = trdelnik_client::idl::parse_to_idl_program(
+        PROGRAM_NAME.to_owned(),
+        expanded_fuzz_example3,
+    )?;
+
+    let program_data = vec![(expanded_fuzz_example3.to_string(), path, program_idl)];
 
     let fuzzer_snapshots =
-        trdelnik_client::snapshot_generator::generate_snapshots_code(&codes_libs_pairs).unwrap();
+        trdelnik_client::snapshot_generator::generate_snapshots_code(&program_data).unwrap();
     let fuzzer_snapshots =
         trdelnik_client::Commander::format_program_code(&fuzzer_snapshots).await?;
 
+    let fuzz_instructions_code =
+        trdelnik_client::fuzzer_generator::generate_source_code(&program_data);
+    let fuzz_instructions_code =
+        trdelnik_client::Commander::format_program_code(&fuzz_instructions_code).await?;
+
     assert_str_eq!(fuzzer_snapshots, expected_accounts_snapshots);
+    assert_str_eq!(fuzz_instructions_code, expected_fuzz_instructions_code);
 }
 
 #[throws]

--- a/crates/client/tests/test_program_client.rs
+++ b/crates/client/tests/test_program_client.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
-use cargo_metadata::camino;
 use fehler::throws;
 use pretty_assertions::assert_str_eq;
+use trdelnik_client::test_generator::ProgramData;
 
 #[throws]
 #[tokio::test]
@@ -9,10 +9,13 @@ pub async fn generate_program_client() {
     // Generate with this command:
     // `trdelnik/examples/escrow/programs/escrow$ cargo expand > escrow_expanded.rs`
     // and the content copy to `test_data/expanded_escrow.rs`
-    let expanded_escrow = include_str!(concat!(
+    let code = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/tests/test_data/expanded_source_codes/expanded_escrow.rs"
     ));
+
+    // for this test we do not need path
+    let path = String::default();
 
     // You can copy the content from the `program_client` crate from an example
     // after you've called `makers trdelnik test`.
@@ -21,14 +24,14 @@ pub async fn generate_program_client() {
         "/tests/test_data/expected_source_codes/expected_program_client_code.rs"
     ));
 
-    let program_idl =
-        trdelnik_client::idl::parse_to_idl_program("escrow".to_owned(), expanded_escrow)?;
+    let program_idl = trdelnik_client::idl::parse_to_idl_program("escrow".to_owned(), code)?;
 
-    let program_data = vec![(
-        String::default(),
-        camino::Utf8PathBuf::default(),
+    let program_data = ProgramData {
+        code: code.to_string(),
+        path: path.into(),
         program_idl,
-    )];
+    };
+    let program_data = vec![program_data];
 
     let use_modules: Vec<syn::ItemUse> = vec![syn::parse_quote! { use trdelnik_client::*; }];
     let client_code = trdelnik_client::program_client_generator::generate_source_code(

--- a/crates/client/tests/test_program_client.rs
+++ b/crates/client/tests/test_program_client.rs
@@ -1,4 +1,5 @@
 use anyhow::Error;
+use cargo_metadata::camino;
 use fehler::throws;
 use pretty_assertions::assert_str_eq;
 
@@ -23,13 +24,17 @@ pub async fn generate_program_client() {
     let program_idl =
         trdelnik_client::idl::parse_to_idl_program("escrow".to_owned(), expanded_escrow)?;
 
-    let idl = trdelnik_client::idl::Idl {
-        programs: vec![program_idl],
-    };
+    let program_data = vec![(
+        String::default(),
+        camino::Utf8PathBuf::default(),
+        program_idl,
+    )];
 
     let use_modules: Vec<syn::ItemUse> = vec![syn::parse_quote! { use trdelnik_client::*; }];
-    let client_code =
-        trdelnik_client::program_client_generator::generate_source_code(&idl, &use_modules);
+    let client_code = trdelnik_client::program_client_generator::generate_source_code(
+        &program_data,
+        &use_modules,
+    );
     let client_code = trdelnik_client::Commander::format_program_code(&client_code).await?;
 
     assert_str_eq!(client_code, expected_client_code);


### PR DESCRIPTION
Currently, once the `accounts_snapshots.rs` file is generated, users need to manually import the structures stored inside the Data Accounts. This PR addresses this issue by obtaining full paths (if possible) to the defined types, employing the same logic used for obtaining full paths to the Instruction input arguments for `.program_client`.

The Test generator has been updated to consolidate all extracted data into a single vector called `programs_data`, rather than using separate fields for IDL and data required for the fuzzer.

Additional minor updates include:
- Adding `use crate::PROGRAM_ID`, as it is often used within `accounts_snapshots.rs` and is available inside `test_fuzz.rs`.
- Implementing small updates to the outputs to enhance the user experience.
